### PR TITLE
fix: dp256 private key clone

### DIFF
--- a/keystore/store/src/generate.ts
+++ b/keystore/store/src/generate.ts
@@ -205,7 +205,7 @@ export async function generateXHDFromParent({
           format: "bytes",
           extractable: true,
           publicKey: dp256.getPurePKBytes(pk),
-          privateKey: { ...pk },
+          privateKey: new Uint8Array(pk),
           metadata: {
             ...metadata,
             parentKeyId: parentKey.id,

--- a/keystore/store/src/generate.ts
+++ b/keystore/store/src/generate.ts
@@ -192,10 +192,12 @@ export async function generateXHDFromParent({
               userHandle: "default",
               counter: 0,
             };
+
         pk = await dp256.genDomainSpecificKeyPair(
           parentKey.privateKey,
           metadata.origin,
-          metadata.userHandle,
+          // Normalize the userHandle
+          metadata.userHandle.toLowerCase(),
           metadata.counter,
         );
         return {


### PR DESCRIPTION
## Description

- normalize user handles when generating from the keystore
- clones the private key using a new Uint8Array