### PR TITLE
feat: accept seed bytes only in importSeed [PERA-4424]

### DIFF
--- a/keystore/react-native/src/extension.ts
+++ b/keystore/react-native/src/extension.ts
@@ -217,7 +217,7 @@ export const WithKeyStore: Extension<KeyStoreExtension> = (
               clearKeyData(key);
             }
           }),
-        /** Imports a raw seed or BIP39 mnemonic for HD wallet derivation */
+        /** Imports a raw seed for HD wallet derivation (convert any mnemonic to seed bytes first) */
         importSeed: (seed, options): Promise<KeyId> =>
           store.importSeed({
             store: keyStore,

--- a/keystore/react-native/src/store.test.ts
+++ b/keystore/react-native/src/store.test.ts
@@ -28,14 +28,6 @@ describe("react-native-keystore store.ts logic", () => {
   describe("importSeed", () => {
     const store = new Store<KeyStoreState>({ keys: [], status: "idle" });
 
-    it("should throw an error for mnemonic import as it is not implemented", async () => {
-      const mnemonic =
-        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
-      await expect(importSeed({ store, seed: mnemonic })).rejects.toThrow(
-        "Mnemonic import is not implemented yet",
-      );
-    });
-
     it("should import a raw Uint8Array seed", async () => {
       const rawSeed = new Uint8Array(64);
       for (let i = 0; i < 64; i++) rawSeed[i] = i;

--- a/keystore/react-native/src/store.ts
+++ b/keystore/react-native/src/store.ts
@@ -254,7 +254,7 @@ export async function importSeed({
   authenticationOptions,
 }: {
   store: Store<KeyStoreState>;
-  seed: Uint8Array | string;
+  seed: Uint8Array;
   name?: string;
   id?: KeyId;
   authenticationOptions?: AuthenticationOptions;
@@ -266,9 +266,6 @@ export async function importSeed({
   const metadata: any = {};
 
   try {
-    if (typeof seed === "string") {
-      throw new InvalidKeyDataError("Mnemonic import is not implemented yet");
-    }
     privateKey = seed;
 
     await commit({

--- a/keystore/store/src/types/backend.ts
+++ b/keystore/store/src/types/backend.ts
@@ -118,13 +118,18 @@ export interface KeyStoreAPI {
   ): Promise<Uint8Array>;
 
   /**
-   * Imports a raw seed (64 bytes / 512 bits) or a BIP39 mnemonic for HD wallets.
+   * Imports a raw seed (64 bytes / 512 bits) for HD wallets.
    *
-   * @param seed - The raw seed bytes or BIP39 mnemonic string.
+   * Accepts seed **bytes only**. A BIP39 mnemonic must be converted to seed
+   * bytes at the call site (e.g. `bip39.mnemonicToSeed`) so the mnemonic
+   * string never crosses into the keystore — an immutable JS string can't be
+   * wiped and would linger in the heap until GC.
+   *
+   * @param seed - The raw seed bytes.
    * @param options - Optional configuration for the seed.
    * @returns The {@link KeyId} assigned to the seed.
    */
-  importSeed?(seed: Uint8Array | string, options?: KeyOptions): Promise<KeyId>;
+  importSeed?(seed: Uint8Array, options?: KeyOptions): Promise<KeyId>;
 
   /**
    * Derives a new key from a seed using HD derivation path.


### PR DESCRIPTION
## Description

`importSeed` now accepts the seed as raw bytes (`Uint8Array`) only — the `Uint8Array | string` union is gone from both `KeyStoreAPI` (`@algorandfoundation/keystore`) and the `react-native-keystore` implementation. A BIP39 mnemonic must be converted to seed bytes at the call site (e.g. `bip39.mnemonicToSeed`), so a mnemonic string never crosses into the keystore — immutable JS strings can't be wiped and would linger in the heap until GC.

No runtime behavior is lost: the string path was never implemented, it only threw `"Mnemonic 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
