### PR TITLE
fix: reduce biometric prompts for master key access

### DIFF
--- a/keystore/react-native/README.md
+++ b/keystore/react-native/README.md
@@ -6,7 +6,7 @@ A secure key management system for the Algorand Wallet Provider. Manage cryptogr
 
 Building a non-custodial wallet requires a **secure, isolated key vault**. The Keystore Extension separates key management from wallet logic:
 
-- **Users** enter a BIP39 mnemonic in the app, which converts it to seed bytes before import
+- **Users** enter a BIP39 mnemonic
 - **Wallet UI** requests signatures without ever seeing the seed or private keys
 - **Keystore backend** handles all cryptographic operations securely
 - **Keys are cleared from memory** immediately after use, never staying in memory

--- a/keystore/react-native/README.md
+++ b/keystore/react-native/README.md
@@ -6,7 +6,7 @@ A secure key management system for the Algorand Wallet Provider. Manage cryptogr
 
 Building a non-custodial wallet requires a **secure, isolated key vault**. The Keystore Extension separates key management from wallet logic:
 
-- **Users** import their BIP39 mnemonic once
+- **Users** enter a BIP39 mnemonic in the app, which converts it to seed bytes before import
 - **Wallet UI** requests signatures without ever seeing the seed or private keys
 - **Keystore backend** handles all cryptographic operations securely
 - **Keys are cleared from memory** immediately after use, never staying in memory
@@ -33,7 +33,7 @@ The React Native backend implements a subset of the [`KeyType`](../store/src/typ
 | `hd-derived-p256`    | `P256`    | XHD-derived P-256 child key (passkey / WebAuthn flows)                              |
 | `ed25519`            | `EdDSA`   | Standalone Ed25519 key derived directly from a `seed` parent (no XHD root required) |
 
-> `ed25519` and `hd-derived-*` keys both require a seed parent supplied via `params.parentKeyId`. Convert any mnemonic to a seed (`importSeed`) before calling `generate`. `RS256` / generic `ecc` / `secret-key` types from the core union are not currently implemented in this backend.
+> `ed25519` and `hd-derived-*` keys both require a seed parent supplied via `params.parentKeyId`. Convert any BIP39 mnemonic to seed bytes before calling `importSeed`, then use the resulting seed ID when calling `generate`. `RS256` / generic `ecc` / `secret-key` types from the core union are not currently implemented in this backend.
 
 ## Quick Start
 
@@ -95,14 +95,19 @@ const signature = await provider.keystore.sign(keyId, data);
 // Private key never exposed — signature is returned directly
 ```
 
-### 4. Import a BIP39 Mnemonic
+### 4. Convert a BIP39 Mnemonic to Seed Bytes and Import It
 
 ```typescript
-// User provides their 25-word seed phrase
+import { mnemonicToSeed } from "@scure/bip39";
+
+// User provides their BIP39 mnemonic
 const mnemonic = "abandon abandon abandon ... about";
 
-const seedId = await provider.keystore.importSeed(mnemonic);
-// Seed is securely stored; never exposed to the wallet UI
+// Convert the BIP39 mnemonic outside the keystore so the mnemonic string never enters it
+const seed = await mnemonicToSeed(mnemonic);
+
+const seedId = await provider.keystore.importSeed(seed);
+// Seed bytes are securely stored; the BIP39 mnemonic itself is not passed to the keystore
 ```
 
 ### 5. Derive Multiple Accounts
@@ -130,9 +135,10 @@ const sig1 = await provider.keystore.sign(account1, data);
 // Generate a new key
 const keyId = await provider.keystore.generate(options);
 
-// Import a key or seed
+// Import a key or raw seed bytes
 const keyId = await provider.keystore.import(keyData, format);
-const seedId = await provider.keystore.importSeed(seed);
+const seedBytes = await mnemonicToSeed(mnemonic);
+const seedId = await provider.keystore.importSeed(seedBytes);
 
 // Export public key (private key never exported)
 const keyData = await provider.keystore.export(keyId);
@@ -163,6 +169,8 @@ await provider.keystore.clear();
 
 ### Seeds (BIP39)
 
+- ✅ **BIP39 mnemonic strings stay outside** the keystore API
+- ✅ **Only seed bytes are imported** into the keystore
 - ✅ **Never exported** after import
 - ✅ **Never shared** with wallet UI
 - ✅ **Derivation happens inside** the secure backend

--- a/keystore/react-native/src/extension.ts
+++ b/keystore/react-native/src/extension.ts
@@ -217,7 +217,7 @@ export const WithKeyStore: Extension<KeyStoreExtension> = (
               clearKeyData(key);
             }
           }),
-        /** Imports a raw seed or BIP39 mnemonic for HD wallet derivation */
+        /** Imports a raw seed for HD wallet derivation (convert any mnemonic to seed bytes first) */
         importSeed: (seed, options): Promise<KeyId> =>
           store.importSeed({
             store: keyStore,

--- a/keystore/react-native/src/storage/crypto.test.ts
+++ b/keystore/react-native/src/storage/crypto.test.ts
@@ -1,8 +1,12 @@
 import * as Keychain from "react-native-keychain";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { decryptData, encryptData, getMasterKey } from "./crypto.js";
 
 describe("crypto storage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("should retrieve or generate a master key", async () => {
     const key = await getMasterKey();
     expect(key).toBeInstanceOf(Buffer);
@@ -28,5 +32,23 @@ describe("crypto storage", () => {
 
     const key = await getMasterKey();
     expect(key.toString("hex")).toBe(storedKey);
+  });
+
+  it("should reuse a recently authenticated biometric master key", async () => {
+    const storedKey = Buffer.alloc(32, 3).toString("hex");
+    vi.mocked(Keychain.getGenericPassword).mockResolvedValueOnce({
+      password: storedKey,
+      username: "master",
+      service: "app-secret",
+      storage: "best",
+    });
+
+    const firstKey = await getMasterKey({ biometrics: true });
+    firstKey.fill(0);
+
+    const secondKey = await getMasterKey({ biometrics: true });
+
+    expect(Keychain.getGenericPassword).toHaveBeenCalledOnce();
+    expect(secondKey.toString("hex")).toBe(storedKey);
   });
 });

--- a/keystore/react-native/src/storage/crypto.ts
+++ b/keystore/react-native/src/storage/crypto.ts
@@ -5,20 +5,26 @@ import type { AuthenticationOptions } from "../types.ts";
 const ALGORITHM = "aes-256-gcm";
 const MASTER_KEY_CACHE_MS = 60_000;
 
-let cachedMasterKey: Buffer | null = null;
+let cachedMasterKey: Buffer | undefined;
 let cachedMasterKeyExpiresAt = 0;
 
-function getCachedMasterKey(): Buffer | null {
+function clearCachedMasterKey() {
+  cachedMasterKey?.fill(0);
+  cachedMasterKey = undefined;
+  cachedMasterKeyExpiresAt = 0;
+}
+
+function getCachedMasterKey(): Buffer | undefined {
   if (!cachedMasterKey || Date.now() > cachedMasterKeyExpiresAt) {
-    cachedMasterKey = null;
-    cachedMasterKeyExpiresAt = 0;
-    return null;
+    clearCachedMasterKey();
+    return undefined;
   }
 
   return Buffer.from(cachedMasterKey);
 }
 
 function cacheMasterKey(key: Buffer) {
+  clearCachedMasterKey();
   cachedMasterKey = Buffer.from(key);
   cachedMasterKeyExpiresAt = Date.now() + MASTER_KEY_CACHE_MS;
 }

--- a/keystore/react-native/src/storage/crypto.ts
+++ b/keystore/react-native/src/storage/crypto.ts
@@ -3,12 +3,36 @@ import { createCipheriv, createDecipheriv, randomBytes } from "react-native-quic
 import type { AuthenticationOptions } from "../types.ts";
 
 const ALGORITHM = "aes-256-gcm";
+const MASTER_KEY_CACHE_MS = 60_000;
+
+let cachedMasterKey: Buffer | null = null;
+let cachedMasterKeyExpiresAt = 0;
+
+function getCachedMasterKey(): Buffer | null {
+  if (!cachedMasterKey || Date.now() > cachedMasterKeyExpiresAt) {
+    cachedMasterKey = null;
+    cachedMasterKeyExpiresAt = 0;
+    return null;
+  }
+
+  return Buffer.from(cachedMasterKey);
+}
+
+function cacheMasterKey(key: Buffer) {
+  cachedMasterKey = Buffer.from(key);
+  cachedMasterKeyExpiresAt = Date.now() + MASTER_KEY_CACHE_MS;
+}
 
 /**
  * Retrieves the master key from the Keychain, or generates a new one if it doesn't exist.
  * @returns The master key as a Buffer
  */
 export async function getMasterKey(options?: AuthenticationOptions): Promise<Buffer> {
+  if (options?.biometrics) {
+    const cached = getCachedMasterKey();
+    if (cached) return cached;
+  }
+
   const prompt = options?.prompt ?? "Authenticate to secure your wallet";
   const authenticationPrompt =
     typeof prompt === "string"
@@ -27,16 +51,19 @@ export async function getMasterKey(options?: AuthenticationOptions): Promise<Buf
     authenticationPrompt,
   });
   if (credentials) {
-    return Buffer.from(credentials.password, "hex");
+    const key = Buffer.from(credentials.password, "hex");
+    if (options?.biometrics) cacheMasterKey(key);
+    return key;
   }
 
   // Create new random key
-  const newKey = randomBytes(32); // TODO: harden entropy
+  const newKey = Buffer.from(randomBytes(32)); // TODO: harden entropy
   await Keychain.setGenericPassword("master", newKey.toString("hex"), {
     service: "app-secret",
     ...biometricOptions,
   });
 
+  if (options?.biometrics) cacheMasterKey(newKey);
   return Buffer.from(newKey);
 }
 

--- a/keystore/react-native/src/store.test.ts
+++ b/keystore/react-native/src/store.test.ts
@@ -28,14 +28,6 @@ describe("react-native-keystore store.ts logic", () => {
   describe("importSeed", () => {
     const store = new Store<KeyStoreState>({ keys: [], status: "idle" });
 
-    it("should throw an error for mnemonic import as it is not implemented", async () => {
-      const mnemonic =
-        "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
-      await expect(importSeed({ store, seed: mnemonic })).rejects.toThrow(
-        "Mnemonic import is not implemented yet",
-      );
-    });
-
     it("should import a raw Uint8Array seed", async () => {
       const rawSeed = new Uint8Array(64);
       for (let i = 0; i < 64; i++) rawSeed[i] = i;

--- a/keystore/react-native/src/store.ts
+++ b/keystore/react-native/src/store.ts
@@ -254,7 +254,7 @@ export async function importSeed({
   authenticationOptions,
 }: {
   store: Store<KeyStoreState>;
-  seed: Uint8Array | string;
+  seed: Uint8Array;
   name?: string;
   id?: KeyId;
   authenticationOptions?: AuthenticationOptions;
@@ -266,9 +266,6 @@ export async function importSeed({
   const metadata: any = {};
 
   try {
-    if (typeof seed === "string") {
-      throw new InvalidKeyDataError("Mnemonic import is not implemented yet");
-    }
     privateKey = seed;
 
     await commit({

--- a/keystore/store/src/types/backend.ts
+++ b/keystore/store/src/types/backend.ts
@@ -118,13 +118,18 @@ export interface KeyStoreAPI {
   ): Promise<Uint8Array>;
 
   /**
-   * Imports a raw seed (64 bytes / 512 bits) or a BIP39 mnemonic for HD wallets.
+   * Imports a raw seed (64 bytes / 512 bits) for HD wallets.
    *
-   * @param seed - The raw seed bytes or BIP39 mnemonic string.
+   * Accepts seed **bytes only**. A BIP39 mnemonic must be converted to seed
+   * bytes at the call site (e.g. `bip39.mnemonicToSeed`) so the mnemonic
+   * string never crosses into the keystore — an immutable JS string can't be
+   * wiped and would linger in the heap until GC.
+   *
+   * @param seed - The raw seed bytes.
    * @param options - Optional configuration for the seed.
    * @returns The {@link KeyId} assigned to the seed.
    */
-  importSeed?(seed: Uint8Array | string, options?: KeyOptions): Promise<KeyId>;
+  importSeed?(seed: Uint8Array, options?: KeyOptions): Promise<KeyId>;
 
   /**
    * Derives a new key from a seed using HD derivation path.

--- a/keystore/store/src/types/backend.ts
+++ b/keystore/store/src/types/backend.ts
@@ -118,7 +118,7 @@ export interface KeyStoreAPI {
   ): Promise<Uint8Array>;
 
   /**
-   * Imports a raw seed (64 bytes / 512 bits) for HD wallets.
+   * Imports raw seed bytes for HD wallets.
    *
    * Accepts seed **bytes only**. A BIP39 mnemonic must be converted to seed
    * bytes at the call site (e.g. `bip39.mnemonicToSeed`) so the mnemonic


### PR DESCRIPTION
## Summary
- stacked on #22 / commit 48a6176 (import seed bytes only) so the biometric prompt fix is tested with the pending seed API change
- cache biometric master key reads briefly to avoid repeated Keychain prompts during multi-step wallet setup flows
- return fresh Buffer copies from the cache so callers can safely mutate or clear their copy
- add regression coverage for biometric master key reuse

## Note
GitHub cannot set this PR's base to #22 directly because #22's head branch (feat/import-seed-bytes-only) exists on a fork/pull ref, not as a branch in algorandfoundation/wallet-provider-extensions. This branch has been rebased on top of #22's head commit instead.

## Verification
- pnpm --filter @algorandfoundation/keystore build
- pnpm --filter @algorandfoundation/log-store build
- pnpm --filter @algorandfoundation/react-native-keystore test
- pnpm --filter @algorandfoundation/react-native-keystore build
- pnpm fmt:check
- pnpm lint (passes with existing warnings)