### PR TITLE
Fix protected main canary releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
         run: pnpm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PACKAGE_RELEASER_SKIP_GIT_PLUGIN: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
       - name: Rebase main onto release
         if: github.ref == 'refs/heads/release' && steps.release.outputs.released == 'true'
         run: |

--- a/build/README.md
+++ b/build/README.md
@@ -93,6 +93,14 @@ Example:
 npm run release -- --dry-run
 ```
 
+## Environment Variables
+
+- `PACKAGE_RELEASER_SKIP_GIT_PLUGIN`: Set to `true` to remove `@semantic-release/git`
+  from the inherited release configuration. This is useful for canary releases from
+  protected branches where GitHub repository rules block release commits pushed by
+  `GITHUB_TOKEN`. Packages, tags, and GitHub releases are still published, but
+  changelog/version commits are not pushed back to the branch.
+
 ## Technical Implementation Details
 
 The tool implements a `semantic-release` inline plugin that:

--- a/build/src/bin.ts
+++ b/build/src/bin.ts
@@ -70,20 +70,32 @@ try {
   console.log(`[${pkg.name}]: Dry run: ${options.dryRun}`);
   console.log(`[${pkg.name}]: Using options ${JSON.stringify(options, null, 2)}`);
 
-  if (options.plugins) {
-    options.plugins = options.plugins.map((plugin) => {
-      if (Array.isArray(plugin) && plugin[0] === "@semantic-release/git") {
-        return [
-          plugin[0],
-          {
-            ...plugin[1],
-            message: `chore(release): ${packageName} \n\n\${nextRelease.notes}`,
-          },
-        ];
-      }
+  const skipGitPlugin = process.env.PACKAGE_RELEASER_SKIP_GIT_PLUGIN === "true";
 
-      return plugin;
-    });
+  if (options.plugins) {
+    options.plugins = options.plugins
+      .filter((plugin) => {
+        const pluginName = Array.isArray(plugin) ? plugin[0] : plugin;
+
+        return !(skipGitPlugin && pluginName === "@semantic-release/git");
+      })
+      .map((plugin) => {
+        if (Array.isArray(plugin) && plugin[0] === "@semantic-release/git") {
+          return [
+            plugin[0],
+            {
+              ...plugin[1],
+              message: `chore(release): ${packageName} \n\n\${nextRelease.notes}`,
+            },
+          ];
+        }
+
+        return plugin;
+      });
+
+    if (skipGitPlugin) {
+      console.log(`[${pkg.name}]: Skipping @semantic-release/git plugin`);
+    }
   }
 
   const monoContext = {


### PR DESCRIPTION
## Summary
- add a package-releaser env switch to omit @semantic-release/git from inherited release config
- set that switch for Release workflow runs on refs/heads/main so canary releases do not push release commits to protected main
- document the env var and its tradeoff

## Root cause
The failing Action was not a build/test regression from the wallet changes. The release job reached @semantic-release/git and attempted to push a release commit back to main with GITHUB_TOKEN. GitHub repository rules rejected that direct push with GH013. This shows up now because the merged package changes triggered a keystore canary release.

## Verification
- pnpm run --filter @algorandfoundation/package-releaser build
- pnpm fmt:check
- pnpm lint (passes with existing warnings)
- pnpm run --if-present build
- PACKAGE_RELEASER_SKIP_GIT_PLUGIN=true pnpm exec package-releaser --dry-run --ci false from keystore/store