### PR TITLE
Fix React Native keystore master key lifecycle

### DIFF
--- a/keystore/react-native/BOOTSTRAPPING.md
+++ b/keystore/react-native/BOOTSTRAPPING.md
@@ -116,8 +116,9 @@ During app startup, you must load the stored keys from persistent storage into t
 // app/_layout.tsx
 import { keyStore } from "@/stores/keystore";
 import {
+  createMasterKey,
   fetchSecret,
-  getMasterKey,
+  readMasterKey,
   storage
 } from "@algorandfoundation/react-native-keystore";
 import {
@@ -132,18 +133,19 @@ import { AlgorandProvider, ReactNativeProvider } from "@/providers/ReactNativePr
 async function bootstrap() {
   setStatus({ store: keyStore as any, status: "loading" });
 
-  // 1. Get the master encryption key from Keychain
-  const masterKey = await getMasterKey();
-
-  // 2. Get all key IDs from MMKV storage
+  // 1. Get all key IDs from MMKV storage
   const keyIds = storage.getAllKeys();
+
+  // 2. Read the master encryption key from Keychain. Only create one when
+  // there are no encrypted records that depend on an existing master key.
+  const masterKey = keyIds.length === 0 ? await createMasterKey() : await readMasterKey();
 
   // 3. Fetch and decrypt each key from MMKV using the master key
   const secrets = await Promise.all(
     keyIds.map(async (keyId) =>
       fetchSecret<KeyData>({
         keyId,
-        masterKey
+        options: { masterKey }
       })
     )
   );
@@ -206,6 +208,6 @@ const provider = new ReactNativeProvider(
 ## Security Best Practices
 
 1.  **Never store private keys in the TanStack store**: Always filter them out during initialization.
-2.  **Use `getMasterKey()`**: Ensure your encryption/decryption uses the master key stored in the secure Keychain.
+2.  **Separate reading from creation**: Use `readMasterKey()` for existing encrypted records, and only call `createMasterKey()` during explicit first-run initialization.
 3.  **Automatic Cleanup**: The `sign`, `derive`, and `generate` methods automatically fetch private keys and clear them from memory after use.
 4.  **MMKV vs Keychain**: Use MMKV for high-performance encrypted storage of key material, and Keychain for the root master key.

--- a/keystore/react-native/__mocks__/react-native-setup.ts
+++ b/keystore/react-native/__mocks__/react-native-setup.ts
@@ -13,6 +13,10 @@ vi.mock("react-native-keychain", () => {
     getGenericPassword: vi.fn(async () => mockPassword),
     setGenericPassword: vi.fn(async (username, password) => {
       mockPassword = { username, password };
+      return true;
+    }),
+    resetGenericPassword: vi.fn(async () => {
+      mockPassword = null;
     }),
     ACCESS_CONTROL: {
       BIOMETRY_ANY: "BIOMETRY_ANY",
@@ -32,6 +36,7 @@ vi.mock("react-native-mmkv", () => {
   const createMock = () => ({
     set: vi.fn((key, value) => mockStorage.set(key, value)),
     getString: vi.fn((key) => mockStorage.get(key)),
+    getAllKeys: vi.fn(() => Array.from(mockStorage.keys())),
     delete: vi.fn((key) => mockStorage.delete(key)),
     remove: vi.fn((key) => mockStorage.delete(key)),
     clearAll: vi.fn(() => mockStorage.clear()),

--- a/keystore/react-native/src/errors.test.ts
+++ b/keystore/react-native/src/errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { DecodingError, EncodingError, UnlockingError } from "./errors.ts";
+import { DecodingError, EncodingError, MasterKeyNotFoundError, UnlockingError } from "./errors.ts";
 
 describe("errors.ts", () => {
   it("DecodingError sets name and message", () => {
@@ -24,5 +24,11 @@ describe("errors.ts", () => {
     const error = new UnlockingError("test message");
     expect(error.message).toBe("test message");
     expect(error.name).toBe("UnlockingError");
+  });
+
+  it("MasterKeyNotFoundError sets name and message", () => {
+    const error = new MasterKeyNotFoundError();
+    expect(error.message).toBe("Master key not found");
+    expect(error.name).toBe("MasterKeyNotFoundError");
   });
 });

--- a/keystore/react-native/src/errors.ts
+++ b/keystore/react-native/src/errors.ts
@@ -39,3 +39,16 @@ export class UnlockingError extends Error {
     }
   }
 }
+
+export class MasterKeyNotFoundError extends Error {
+  constructor(message = "Master key not found", cause?: Error) {
+    super(message);
+    this.name = "MasterKeyNotFoundError";
+    if (cause) {
+      this.cause = cause;
+    }
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, MasterKeyNotFoundError);
+    }
+  }
+}

--- a/keystore/react-native/src/storage/crypto.test.ts
+++ b/keystore/react-native/src/storage/crypto.test.ts
@@ -1,16 +1,29 @@
 import * as Keychain from "react-native-keychain";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { decryptData, encryptData, getMasterKey } from "./crypto.js";
+import { MasterKeyNotFoundError, UnlockingError } from "../errors.js";
+import { createMasterKey, decryptData, encryptData, readMasterKey } from "./crypto.js";
 
 describe("crypto storage", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
+    await Keychain.resetGenericPassword();
   });
 
-  it("should retrieve or generate a master key", async () => {
-    const key = await getMasterKey();
+  it("should create a master key", async () => {
+    const key = await createMasterKey();
     expect(key).toBeInstanceOf(Buffer);
     expect(key.length).toBe(32);
+    expect(Keychain.setGenericPassword).toHaveBeenCalledOnce();
+  });
+
+  it("should not create a master key while reading", async () => {
+    await expect(readMasterKey()).rejects.toBeInstanceOf(MasterKeyNotFoundError);
+    expect(Keychain.setGenericPassword).not.toHaveBeenCalled();
+  });
+
+  it("should fail when the master key cannot be stored", async () => {
+    vi.mocked(Keychain.setGenericPassword).mockResolvedValueOnce(false);
+    await expect(createMasterKey()).rejects.toBeInstanceOf(UnlockingError);
   });
 
   it("should encrypt and decrypt data", () => {
@@ -30,7 +43,7 @@ describe("crypto storage", () => {
       storage: "best",
     });
 
-    const key = await getMasterKey();
+    const key = await readMasterKey();
     expect(key.toString("hex")).toBe(storedKey);
   });
 
@@ -43,10 +56,10 @@ describe("crypto storage", () => {
       storage: "best",
     });
 
-    const firstKey = await getMasterKey({ biometrics: true });
+    const firstKey = await readMasterKey({ biometrics: true });
     firstKey.fill(0);
 
-    const secondKey = await getMasterKey({ biometrics: true });
+    const secondKey = await readMasterKey({ biometrics: true });
 
     expect(Keychain.getGenericPassword).toHaveBeenCalledOnce();
     expect(secondKey.toString("hex")).toBe(storedKey);

--- a/keystore/react-native/src/storage/crypto.ts
+++ b/keystore/react-native/src/storage/crypto.ts
@@ -1,5 +1,6 @@
 import * as Keychain from "react-native-keychain";
 import { createCipheriv, createDecipheriv, randomBytes } from "react-native-quick-crypto";
+import { MasterKeyNotFoundError, UnlockingError } from "../errors.ts";
 import type { AuthenticationOptions } from "../types.ts";
 
 const ALGORITHM = "aes-256-gcm";
@@ -30,15 +31,47 @@ function cacheMasterKey(key: Buffer) {
 }
 
 /**
- * Retrieves the master key from the Keychain, or generates a new one if it doesn't exist.
+ * Reads the existing master key from the Keychain.
+ *
+ * This never creates a replacement key. A falsey Keychain result can mean
+ * either "missing" or "failed to read"; callers must decide whether creation
+ * is safe for their current storage state.
+ *
  * @returns The master key as a Buffer
  */
-export async function getMasterKey(options?: AuthenticationOptions): Promise<Buffer> {
+export async function readMasterKey(options?: AuthenticationOptions): Promise<Buffer> {
   if (options?.biometrics) {
     const cached = getCachedMasterKey();
     if (cached) return cached;
   }
 
+  const prompt = options?.prompt ?? "Authenticate to secure your wallet";
+  const authenticationPrompt =
+    typeof prompt === "string"
+      ? { title: prompt }
+      : (prompt ?? { title: "Authenticate to secure your wallet" });
+  const credentials = await Keychain.getGenericPassword({
+    service: "app-secret",
+    authenticationPrompt,
+  });
+  if (credentials) {
+    const key = Buffer.from(credentials.password, "hex");
+    if (options?.biometrics) cacheMasterKey(key);
+    return key;
+  }
+
+  throw new MasterKeyNotFoundError();
+}
+
+/**
+ * Creates and stores a new master key.
+ *
+ * Only call this from explicit initialization paths where there are no
+ * encrypted keystore records that depend on a previous master key.
+ *
+ * @returns The newly created master key as a Buffer
+ */
+export async function createMasterKey(options?: AuthenticationOptions): Promise<Buffer> {
   const prompt = options?.prompt ?? "Authenticate to secure your wallet";
   const authenticationPrompt =
     typeof prompt === "string"
@@ -52,22 +85,14 @@ export async function getMasterKey(options?: AuthenticationOptions): Promise<Buf
       }
     : {};
 
-  const credentials = await Keychain.getGenericPassword({
-    service: "app-secret",
-    authenticationPrompt,
-  });
-  if (credentials) {
-    const key = Buffer.from(credentials.password, "hex");
-    if (options?.biometrics) cacheMasterKey(key);
-    return key;
-  }
-
-  // Create new random key
   const newKey = Buffer.from(randomBytes(32)); // TODO: harden entropy
-  await Keychain.setGenericPassword("master", newKey.toString("hex"), {
+  const result = await Keychain.setGenericPassword("master", newKey.toString("hex"), {
     service: "app-secret",
     ...biometricOptions,
   });
+  if (!result) {
+    throw new UnlockingError("Failed to store master key");
+  }
 
   if (options?.biometrics) cacheMasterKey(newKey);
   return Buffer.from(newKey);

--- a/keystore/react-native/src/storage/state.test.ts
+++ b/keystore/react-native/src/storage/state.test.ts
@@ -1,9 +1,16 @@
 import type { KeyData, KeyStoreState } from "@algorandfoundation/keystore";
 import { Store } from "@tanstack/store";
-import { describe, expect, it } from "vitest";
+import * as Keychain from "react-native-keychain";
+import { beforeEach, describe, expect, it } from "vitest";
+import { MasterKeyNotFoundError } from "../errors.js";
 import { commit, fetchSecret, storage } from "./state.js";
 
 describe("state storage", () => {
+  beforeEach(async () => {
+    storage.clearAll();
+    await Keychain.resetGenericPassword();
+  });
+
   it("should commit and fetch a secret", async () => {
     const store = new Store<KeyStoreState>({
       keys: [],
@@ -45,6 +52,14 @@ describe("state storage", () => {
         42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42,
         42, 42, 42, 42, 42, 42, 42, 42, 42,
       ]),
+    );
+  });
+
+  it("does not create a replacement master key when encrypted storage already exists", async () => {
+    storage.set("existing-key", "encrypted-with-another-master-key");
+
+    await expect(fetchSecret<KeyData>({ keyId: "existing-key" })).rejects.toBeInstanceOf(
+      MasterKeyNotFoundError,
     );
   });
 });

--- a/keystore/react-native/src/storage/state.ts
+++ b/keystore/react-native/src/storage/state.ts
@@ -10,13 +10,24 @@ import { clearBuffer } from "@algorandfoundation/wallet-provider";
 import { base64url } from "@scure/base";
 import type { Store } from "@tanstack/store";
 import { createMMKV, type MMKV } from "react-native-mmkv";
-import { decryptData, encryptData, getMasterKey } from "./crypto.ts";
+import { MasterKeyNotFoundError } from "../errors.ts";
 import type { AuthenticationOptions } from "../types.ts";
+import { createMasterKey, decryptData, encryptData, readMasterKey } from "./crypto.ts";
 
 export const storage: MMKV = createMMKV({
   id: "keystore",
   mode: "multi-process",
 });
+
+async function readOrCreateMasterKeyForEmptyStorage(options?: AuthenticationOptions) {
+  try {
+    return await readMasterKey(options);
+  } catch (error) {
+    if (!(error instanceof MasterKeyNotFoundError)) throw error;
+    if (storage.getAllKeys().length > 0) throw error;
+    return createMasterKey(options);
+  }
+}
 
 /**
  * Fetches a secret from persistent storage and decrypts it using the master key.
@@ -38,7 +49,7 @@ export async function fetchSecret<T>({
     const encryptedData = storage.getString(keyId);
     if (!encryptedData) return null;
     if (!key) {
-      key = await getMasterKey(options);
+      key = await readMasterKey(options);
       isInternalKey = true;
     }
     return decode(decryptData(key, encryptedData)) as T;
@@ -82,7 +93,10 @@ export async function commit({
 
   try {
     // Never allow the master key to touch memory.
-    storage.set(keyData.id, encryptData(await getMasterKey(options), encode(keyData)));
+    storage.set(
+      keyData.id,
+      encryptData(await readOrCreateMasterKeyForEmptyStorage(options), encode(keyData)),
+    );
     // remove the private keys from keyData
     const { privateKey, seed, ...keyState } = keyData as any;
     // clear then delete the keys from the keyData object to remove it from memory, even from the caller 😈


### PR DESCRIPTION
## Summary
- split master key access into readMasterKey and createMasterKey
- prevent missing/unreadable master keys from silently rotating when encrypted records exist
- add explicit MasterKeyNotFoundError coverage and update bootstrapping docs

## Verification
- corepack pnpm --filter @algorandfoundation/react-native-keystore test
- corepack pnpm --filter @algorandfoundation/react-native-keystore build
- corepack pnpm fmt:check