### PR TITLE
feat(migrations): opt-in data migrations engine for provider extensions

### DIFF
--- a/examples/react-native-wallet/app/_layout.tsx
+++ b/examples/react-native-wallet/app/_layout.tsx
@@ -6,6 +6,7 @@ import { keyStore } from "@/stores/keystore";
 import { keyStoreHooks, accountHooks } from "@/stores/before-after";
 import { accountsStore } from "@/stores/accounts";
 import { identitiesStore } from "@/stores/identities";
+import { migrationsLedger } from "@/stores/migrations";
 import type { ReactKeystoreOptions } from "@algorandfoundation/react-native-keystore";
 
 install();
@@ -19,45 +20,50 @@ const biometricOptions: ReactKeystoreOptions["keystore"]["authentication"] = {
   prompt: "Authenticate to access your wallet",
 };
 
+/**
+ * The single provider instance for the application.
+ *
+ * Constructed at module scope, not inside the component: a new instance per
+ * render would re-register every extension and re-run migrations on each pass.
+ */
+const provider = new ReactNativeProvider(
+  {
+    id: "wallet-provider",
+    name: "Wallet Provider",
+  },
+  {
+    migrations: { ledger: migrationsLedger },
+    logs: {},
+    accounts: {
+      store: accountsStore,
+      hooks: accountHooks,
+      keystore: {
+        autoPopulate: true,
+      },
+    },
+    identities: {
+      store: identitiesStore,
+      keystore: {
+        autoPopulate: true,
+      },
+    },
+    keystore: {
+      store: keyStore,
+      hooks: keyStoreHooks,
+      // React Native has no reliable global `crypto.subtle`, so the
+      // host Subtle must be supplied explicitly. `react-native-quick-crypto`'s
+      // `subtle` backs the engine's AES-256-GCM at-rest sealing (without
+      // it, sealing a new seed throws "Cannot read property 'importKey'
+      // of undefined").
+      subtle: subtle as unknown as SubtleCrypto,
+      authentication: biometricOptions,
+    },
+  },
+);
+
 export default function RootLayout() {
   return (
-    <AlgorandProvider
-      provider={
-        new ReactNativeProvider(
-          {
-            id: "wallet-provider",
-            name: "Wallet Provider",
-          },
-          {
-            logs: {},
-            accounts: {
-              store: accountsStore,
-              hooks: accountHooks,
-              keystore: {
-                autoPopulate: true,
-              },
-            },
-            identities: {
-              store: identitiesStore,
-              keystore: {
-                autoPopulate: true,
-              },
-            },
-            keystore: {
-              store: keyStore,
-              hooks: keyStoreHooks,
-              // React Native has no reliable global `crypto.subtle`, so the
-              // host Subtle must be supplied explicitly. `react-native-quick-crypto`'s
-              // `subtle` backs the engine's AES-256-GCM at-rest sealing (without
-              // it, sealing a new seed throws "Cannot read property 'importKey'
-              // of undefined").
-              subtle: subtle as unknown as SubtleCrypto,
-              authentication: biometricOptions,
-            },
-          },
-        )
-      }
-    >
+    <AlgorandProvider provider={provider}>
       <Stack
         screenOptions={{
           headerShadowVisible: false,

--- a/examples/react-native-wallet/app/index.tsx
+++ b/examples/react-native-wallet/app/index.tsx
@@ -1,5 +1,14 @@
-import { Text, View, StyleSheet, SafeAreaView, ScrollView, StatusBar } from "react-native";
+import {
+  Text,
+  View,
+  StyleSheet,
+  SafeAreaView,
+  ScrollView,
+  StatusBar,
+  ActivityIndicator,
+} from "react-native";
 import { useKeys, useAccounts, useIdentities, useProvider } from "@/hooks/useProvider";
+import { useMigrations } from "@/hooks/useMigrations";
 import { HeaderCard, ExtensionCard } from "@/components";
 import type { ExtensionCardProps } from "@/components";
 
@@ -19,10 +28,28 @@ interface Domain {
 }
 
 export default function Index() {
+  const { pending: migrationsPending, error: migrationsError } = useMigrations();
   const provider = useProvider();
   const keys = useKeys();
   const accounts = useAccounts();
   const identities = useIdentities();
+
+  if (migrationsPending) {
+    return (
+      <View style={{ flex: 1, alignItems: "center", justifyContent: "center" }}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  if (migrationsError) {
+    return (
+      <View style={{ flex: 1, alignItems: "center", justifyContent: "center", padding: 24 }}>
+        <Text style={{ fontWeight: "bold", marginBottom: 8 }}>Migration failed</Text>
+        <Text>{migrationsError.message}</Text>
+      </View>
+    );
+  }
 
   const domains: Domain[] = [
     {

--- a/examples/react-native-wallet/hooks/useMigrations.ts
+++ b/examples/react-native-wallet/hooks/useMigrations.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+import { useProvider } from "@/hooks/useProvider";
+
+/** The state of the application's one-time migration run. */
+export interface MigrationsState {
+  /** True until the run settles. */
+  pending: boolean;
+  /** Set when the run failed; the app should not read migrated data. */
+  error: Error | null;
+}
+
+/**
+ * Awaits the provider's migration run.
+ *
+ * Gate anything that reads persisted data on `pending` being false, and surface
+ * `error` rather than swallowing it — a failed migration means the data on disk
+ * is not in the shape this build expects.
+ *
+ * @returns The current {@link MigrationsState}.
+ *
+ * @example
+ * ```tsx
+ * const { pending, error } = useMigrations();
+ * if (pending) return <ActivityIndicator />;
+ * if (error) return <Text>Migration failed: {error.message}</Text>;
+ * ```
+ */
+export function useMigrations(): MigrationsState {
+  const provider = useProvider();
+  const [state, setState] = useState<MigrationsState>({ pending: true, error: null });
+
+  useEffect(() => {
+    let active = true;
+    provider.migrations.ready.then(
+      () => {
+        if (active) setState({ pending: false, error: null });
+      },
+      (error: Error) => {
+        if (active) setState({ pending: false, error });
+      },
+    );
+    return () => {
+      active = false;
+    };
+  }, [provider]);
+
+  return state;
+}

--- a/examples/react-native-wallet/package.json
+++ b/examples/react-native-wallet/package.json
@@ -18,6 +18,7 @@
     "@algorandfoundation/identities-store": "workspace:*",
     "@algorandfoundation/keystore": "workspace:*",
     "@algorandfoundation/log-store": "workspace:*",
+    "@algorandfoundation/provider-migrations": "workspace:*",
     "@algorandfoundation/react-native-keystore": "workspace:*",
     "@algorandfoundation/wallet-provider": "catalog:",
     "@expo/vector-icons": "^15.0.3",

--- a/examples/react-native-wallet/providers/ReactNativeProvider.tsx
+++ b/examples/react-native-wallet/providers/ReactNativeProvider.tsx
@@ -1,6 +1,7 @@
 import { createContext, type ReactNode } from "react";
 import { Provider } from "@algorandfoundation/wallet-provider";
 
+import { WithMigrations, type MigrationsApi } from "@algorandfoundation/provider-migrations";
 import { WithKeyStore } from "@algorandfoundation/react-native-keystore";
 import { Account, AccountStoreApi, WithAccountStore } from "@algorandfoundation/accounts-store";
 import type { KeyStoreAPI, KeyStoreCapability, Key } from "@algorandfoundation/keystore";
@@ -26,6 +27,7 @@ export type AppAccount = WatchedAccount | KeystoreAccount | Account;
  */
 export class ReactNativeProvider extends Provider<typeof ReactNativeProvider.EXTENSIONS> {
   static EXTENSIONS = [
+    WithMigrations,
     WithLogStore,
     WithKeyStore,
     WithAccountStore<AppAccount>,
@@ -34,6 +36,8 @@ export class ReactNativeProvider extends Provider<typeof ReactNativeProvider.EXT
     WithWatchedAccount,
   ] as const;
 
+  /** Data migration registry and run control */
+  migrations!: MigrationsApi;
   /** Reactive array of keys in the keystore */
   keys!: Key[];
   /** Reactive array of accounts in the account store */

--- a/examples/react-native-wallet/stores/migrations.ts
+++ b/examples/react-native-wallet/stores/migrations.ts
@@ -1,0 +1,21 @@
+import { keyValueLedger } from "@algorandfoundation/provider-migrations";
+import type { MigrationLedger } from "@algorandfoundation/provider-migrations";
+import { localStorage } from "@/stores/mmkv-local";
+
+/**
+ * The durable migration ledger, backed by the app's general-purpose MMKV
+ * instance — deliberately separate from the `keystore` MMKV so the ledger
+ * survives operations that clear key material.
+ *
+ * The separation cuts both ways: if the `keystore` MMKV is cleared, or
+ * restored from a backup older than this app's data, the ledger still says
+ * every revision up to the last-recorded one has been applied. Restored
+ * legacy records are then never re-flagged, because from the ledger's point
+ * of view nothing changed.
+ */
+export const migrationsLedger: MigrationLedger = keyValueLedger({
+  get: (key) => localStorage.getString(key),
+  set: (key, value) => {
+    localStorage.set(key, value);
+  },
+});

--- a/keystore/react-native/README.md
+++ b/keystore/react-native/README.md
@@ -2,6 +2,40 @@
 
 A secure key management system for the Algorand Wallet Provider. Manage cryptographic keys, derive HD wallets from BIP39 seeds, and sign arbitrary data—all while keeping private keys locked away in a secure vault.
 
+## Migrations
+
+This package registers its data migrations with
+[`@algorandfoundation/provider-migrations`](../../migrations) when that extension
+is present on the provider.
+
+> **Breaking change.** Legacy passkey flagging (records derived from the XHD root
+> before the deterministic-P256 split) used to run automatically on every engine
+> start. It is now revision `0001` and runs only when `WithMigrations` is
+> installed. `@algorandfoundation/provider-migrations` is an **optional peer
+> dependency** — it is not installed for you — so add it first:
+>
+> ```bash
+> pnpm add @algorandfoundation/provider-migrations
+> ```
+>
+> Then add it — **first** — to your provider:
+>
+> ```typescript
+> import { WithMigrations, keyValueLedger } from "@algorandfoundation/provider-migrations";
+>
+> const MyProvider = Provider.withExtensions([WithMigrations, WithKeyStore]);
+> const provider = new MyProvider(config, {
+>   migrations: {
+>     ledger: keyValueLedger({ get: (k) => mmkv.getString(k), set: (k, v) => mmkv.set(k, v) }),
+>   },
+>   keystore: { store, hooks },
+> });
+> await provider.migrations.ready;
+> ```
+>
+> Without it, legacy passkeys are never flagged and the UI cannot prompt users to
+> recreate them.
+
 ## Why This Exists
 
 Building a non-custodial wallet requires a **secure, isolated key vault**. The Keystore Extension separates key management from wallet logic:

--- a/keystore/react-native/package.json
+++ b/keystore/react-native/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@algorandfoundation/package-releaser": "workspace:^",
+    "@algorandfoundation/provider-migrations": "workspace:*",
     "falcon-1024": "catalog:",
     "react-native": "catalog:",
     "typedoc": "catalog:",
@@ -56,12 +57,16 @@
   },
   "peerDependencies": {
     "@algorandfoundation/log-store": "workspace:*",
+    "@algorandfoundation/provider-migrations": "workspace:*",
     "@joe-p/react-native-falcon": "^0.1.0",
     "@tanstack/store": "catalog:",
     "before-after-hook": "catalog:"
   },
   "peerDependenciesMeta": {
     "@algorandfoundation/log-store": {
+      "optional": true
+    },
+    "@algorandfoundation/provider-migrations": {
       "optional": true
     },
     "@joe-p/react-native-falcon": {

--- a/keystore/react-native/src/engine.test.ts
+++ b/keystore/react-native/src/engine.test.ts
@@ -13,11 +13,8 @@ import * as Keychain from "react-native-keychain";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createReactNativeKeyStore, type ReactNativeKeyStore } from "./engine.ts";
-import {
-  type KeychainStorage,
-  migrateLegacyPasskeys,
-  PASSKEY_MIGRATION_NEEDED,
-} from "./storage/driver.ts";
+import { memoryStorage, seedLegacyPasskey } from "./storage/__fixtures__.ts";
+import { migrateLegacyPasskeys, PASSKEY_MIGRATION_NEEDED } from "./storage/driver.ts";
 
 const message = new TextEncoder().encode("the quick brown fox");
 // The setup file (see vitest.config.ts) points global.crypto at Node webcrypto,
@@ -58,22 +55,6 @@ const dp256: DP256Binding = {
 };
 
 const shims: SubtleShim[] = [(h) => withSubtleXHD(h, xhd), (h) => withSubtleDP256(h, dp256)];
-
-/** A fresh in-memory MMKV-style store per test (real Keychain master is mocked). */
-function memoryStorage(): KeychainStorage & { entries(): [string, string][] } {
-  const map = new Map<string, string>();
-  return {
-    getString: (key) => map.get(key),
-    set: (key, value) => {
-      map.set(key, value);
-    },
-    remove: (key) => {
-      map.delete(key);
-    },
-    getAllKeys: () => [...map.keys()],
-    entries: () => [...map.entries()],
-  };
-}
 
 describe("createReactNativeKeyStore", () => {
   let store: Store<KeyStoreState>;
@@ -392,28 +373,6 @@ describe("operation tagging", () => {
 });
 
 describe("migrateLegacyPasskeys", () => {
-  /** Seeds a legacy passkey metadata record (pre-dp256-split, no `scheme`). */
-  function seedLegacyPasskey(storage: KeychainStorage, id: string): void {
-    storage.set(
-      `k/${id}`,
-      JSON.stringify({
-        id,
-        type: "hd-derived-p256",
-        algorithm: "P256",
-        extractable: false,
-        keyUsages: ["sign", "verify"],
-        metadata: {
-          storage: "none",
-          origin: "https://example.com",
-          userHandle: "user-123",
-          counter: 0,
-          parentKeyId: "xhd-root-1",
-        },
-        version: 1,
-      }),
-    );
-  }
-
   it("flags a legacy passkey needs-migration in place, without copying", () => {
     const storage = memoryStorage();
     seedLegacyPasskey(storage, "pk1");
@@ -461,15 +420,106 @@ describe("migrateLegacyPasskeys", () => {
     expect(pk2.metadata.migration).toBeUndefined();
   });
 
-  it("surfaces migration markers in the reactive store on startup", async () => {
+  it("surfaces migration markers in the reactive store once `before` completes", async () => {
     const storage = memoryStorage();
     seedLegacyPasskey(storage, "pk1");
 
     const store = new Store<KeyStoreState>({ keys: [], status: "idle" });
-    const keystore = createReactNativeKeyStore({ store, subtle, shims, storage });
+    const keystore = createReactNativeKeyStore({
+      store,
+      subtle,
+      shims,
+      storage,
+      before: Promise.resolve().then(() => {
+        migrateLegacyPasskeys(storage);
+      }),
+    });
     await keystore.ready;
 
     const marker = store.state.keys.find((k) => k.id === "pk1");
     expect(marker?.metadata?.migration).toBe(PASSKEY_MIGRATION_NEEDED);
+  });
+});
+
+describe("createReactNativeKeyStore — `before` gate", () => {
+  it("does not settle `ready` until `before` settles", async () => {
+    const storage = memoryStorage();
+    const store = new Store<KeyStoreState>({ keys: [], status: "idle" });
+    let release!: () => void;
+    const before = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const keystore = createReactNativeKeyStore({
+      store,
+      subtle: globalThis.crypto.subtle,
+      storage,
+      shims: [], // no dynamic import, so the gate is the only thing holding `ready`
+      before,
+    });
+
+    let settled = false;
+    void keystore.ready.then(() => {
+      settled = true;
+    });
+
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+    expect(settled).toBe(false);
+
+    release();
+    await keystore.ready;
+    expect(settled).toBe(true);
+  });
+
+  it("resolves normally when `before` is omitted", async () => {
+    const storage = memoryStorage();
+    const store = new Store<KeyStoreState>({ keys: [], status: "idle" });
+
+    const keystore = createReactNativeKeyStore({
+      store,
+      subtle: globalThis.crypto.subtle,
+      storage,
+    });
+
+    await expect(keystore.ready).resolves.toBeUndefined();
+  });
+
+  it("rejects `ready` when `before` rejects", async () => {
+    const storage = memoryStorage();
+    const store = new Store<KeyStoreState>({ keys: [], status: "idle" });
+
+    const keystore = createReactNativeKeyStore({
+      store,
+      subtle: globalThis.crypto.subtle,
+      storage,
+      before: Promise.reject(new Error("migrations failed")),
+    });
+
+    await expect(keystore.ready).rejects.toThrow("migrations failed");
+  });
+
+  it("never raises an unhandled rejection when `before` rejects and nobody awaits `ready`, yet a caller who does await still sees the rejection", async () => {
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+
+    const storage = memoryStorage();
+    const store = new Store<KeyStoreState>({ keys: [], status: "idle" });
+
+    const keystore = createReactNativeKeyStore({
+      store,
+      subtle: globalThis.crypto.subtle,
+      storage,
+      before: Promise.reject(new Error("migrations failed")),
+    });
+    // Deliberately not awaiting `keystore.ready` here, e.g. an app that
+    // renders a "migration failed" screen and never touches `key.store`.
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    process.off("unhandledRejection", unhandled);
+
+    expect(unhandled).not.toHaveBeenCalled();
+
+    // The rejection is not swallowed: a caller who does await still observes it.
+    await expect(keystore.ready).rejects.toThrow("migrations failed");
   });
 });

--- a/keystore/react-native/src/engine.ts
+++ b/keystore/react-native/src/engine.ts
@@ -38,7 +38,6 @@ import {
   createKeychainDriver,
   type KeychainCrypto,
   type KeychainStorage,
-  migrateLegacyPasskeys,
 } from "./storage/driver.ts";
 import { storage as defaultStorage } from "./storage/state.ts";
 import type { AuthenticationOperation, AuthenticationOptions } from "./types.ts";
@@ -89,6 +88,18 @@ export interface ReactNativeKeyStoreOptions {
    * behaviour where authentication options were applied to every operation.
    */
   authentication?: AuthenticationOptions;
+  /**
+   * Work that must complete before the engine reads any persisted state.
+   *
+   * The keystore hydrates its reactive store from the driver during `ready`, so
+   * anything that rewrites persisted metadata — notably a migration run — has to
+   * finish first or the store mirrors pre-migration data. `WithKeyStore` passes
+   * `provider.migrations?.ready` here.
+   *
+   * A rejection propagates to `ready`: a keystore whose data failed to migrate
+   * is not one an application should read from.
+   */
+  before?: Promise<unknown>;
 }
 
 /**
@@ -299,13 +310,14 @@ export function createReactNativeKeyStore(
     wipe: (key) => key.fill(0),
   };
 
-  // Non-destructively flag any legacy passkeys (derived from the XHD root under
-  // the old scheme) as needing migration before the core engine hydrates its
-  // metadata, so the reactive store surfaces the markers on first launch. This
-  // is metadata-only — no material is decrypted and no biometric prompt fires.
-  migrateLegacyPasskeys(storage);
-
   const driver = createKeychainDriver({ storage, crypto });
+
+  // Anything that rewrites persisted metadata (a migration run) must finish
+  // before core hydrates its reactive store from the driver, otherwise the
+  // store mirrors pre-migration data.
+  const gated = options.before
+    ? { ...driver, ready: options.before.then(() => driver.ready) }
+    : driver;
 
   // When the caller passes no explicit `shims`, build the default set lazily so
   // the native `@joe-p/react-native-falcon` binding can be loaded asynchronously and
@@ -320,11 +332,24 @@ export function createReactNativeKeyStore(
     });
 
   const keystore = createKeyStore<AuthenticationOptions>({
-    driver,
+    driver: gated,
     store: options.store,
     subtle: options.subtle,
     shims,
     hooks: options.hooks,
+  });
+
+  // An application is free never to await `keystore.ready` (e.g. it renders a
+  // "migration failed" screen and never touches `key.store`). Core's `ready`
+  // awaits `driver.ready` — the `before`-gated promise above — internally, so
+  // when `before` rejects, that rejection propagates to `keystore.ready`
+  // itself; without a handler attached to it, that would surface as an
+  // unhandled promise rejection. `.catch()` registers a handler on this exact
+  // promise (not just on the derived one it returns), so it does not swallow
+  // anything: a caller who does `await keystore.ready` still observes the
+  // rejection normally.
+  keystore.ready.catch(() => {
+    /* surfaced through `ready` to whoever awaits it */
   });
 
   return withOperationTags(keystore, options.store, defaultAuth);

--- a/keystore/react-native/src/extension.test.ts
+++ b/keystore/react-native/src/extension.test.ts
@@ -12,7 +12,12 @@ import Hook from "before-after-hook";
 import { describe, expect, it, vi } from "vitest";
 
 import { WithKeyStore } from "./extension.ts";
+import {
+  memoryStorage as fixtureMemoryStorage,
+  seedLegacyPasskey,
+} from "./storage/__fixtures__.ts";
 import type { KeychainStorage } from "./storage/driver.ts";
+import { PASSKEY_MIGRATION_NEEDED } from "./storage/driver.ts";
 import type { ReactKeystoreOptions } from "./types.ts";
 
 const message = new TextEncoder().encode("the quick brown fox");
@@ -71,7 +76,7 @@ function createTestSetup() {
   const options: ReactKeystoreOptions = {
     keystore: { store, hooks, subtle, shims, storage },
   };
-  const provider = { log: { debug: vi.fn() } } as any;
+  const provider = { log: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() } } as any;
   const extension = WithKeyStore(provider, options);
   return { store, hooks, storage, extension };
 }
@@ -208,5 +213,117 @@ describe("WithKeyStore Extension", () => {
       await extension.key.store.verify(id1, new TextEncoder().encode("msg1"), signatures[0]!),
     ).toBe(true);
     expect(batchBefore).toHaveBeenCalled();
+  });
+});
+
+describe("WithKeyStore — migrations registration", () => {
+  it("registers its migration module when the provider carries one", () => {
+    const register = vi.fn();
+    const provider: any = { migrations: { register, ready: Promise.resolve() } };
+
+    WithKeyStore(provider, {
+      keystore: { store: new Store<KeyStoreState>({ keys: [], status: "idle" }) },
+      api: { keystore: {} as any },
+    } as any);
+
+    expect(register).toHaveBeenCalledTimes(1);
+    const registered = register.mock.calls[0]![0];
+    expect(registered.module).toBe("@algorandfoundation/react-native-keystore");
+    expect(registered.migrations.map((m: { id: number }) => m.id)).toEqual([1]);
+  });
+
+  it("is a no-op when the provider has no migrations extension", () => {
+    expect(() =>
+      WithKeyStore(
+        {} as any,
+        {
+          keystore: { store: new Store<KeyStoreState>({ keys: [], status: "idle" }) },
+          api: { keystore: {} as any },
+        } as any,
+      ),
+    ).not.toThrow();
+  });
+
+  it("warns via the log extension when no migrations extension is installed", () => {
+    const warn = vi.fn();
+    const provider: any = { log: { warn } };
+
+    WithKeyStore(provider, {
+      keystore: { store: new Store<KeyStoreState>({ keys: [], status: "idle" }) },
+      api: { keystore: {} as any },
+    } as any);
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const [message] = warn.mock.calls[0]!;
+    expect(message).toContain("@algorandfoundation/react-native-keystore");
+    expect(message).toContain("WithMigrations");
+  });
+
+  it("does not throw when neither a migrations nor a log extension is present", () => {
+    expect(() =>
+      WithKeyStore(
+        {} as any,
+        {
+          keystore: { store: new Store<KeyStoreState>({ keys: [], status: "idle" }) },
+          api: { keystore: {} as any },
+        } as any,
+      ),
+    ).not.toThrow();
+  });
+
+  it("closes the loop: a legacy passkey flagged by the registered migration surfaces in the engine's keys", async () => {
+    const register = vi.fn();
+    // `ready` only settles once the test below has actually driven the
+    // registered migration against `registered.context()` — mirroring the
+    // real gate in `createReactNativeKeyStore` (`before`), so the engine
+    // cannot hydrate before the migration has run.
+    let resolveReady!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      resolveReady = resolve;
+    });
+    const provider: any = { migrations: { register, ready } };
+    const storage = fixtureMemoryStorage();
+    seedLegacyPasskey(storage, "pk1");
+
+    // No `api.keystore` here — this exercises the real
+    // `createReactNativeKeyStore` path, not the injected-backend shortcut, so
+    // the assertion below pins down the actual engine's storage, not a stub's.
+    const extension = WithKeyStore(provider, {
+      keystore: {
+        store: new Store<KeyStoreState>({ keys: [], status: "idle" }),
+        subtle: globalThis.crypto.subtle,
+        // Explicit shims (empty) sidestep the default set's dynamic Falcon
+        // import — irrelevant here and would only slow the test down.
+        shims: [],
+        storage,
+      },
+    } as any);
+
+    expect(register).toHaveBeenCalledTimes(1);
+    const registered = register.mock.calls[0]![0];
+
+    // Drive the migration exactly as `applyMigrations` would: against the
+    // context the module registered, not the local `storage` fixture
+    // directly. If `extension.ts` ever built the engine from a *different*
+    // storage instance than the one it registered, this still writes the
+    // flag to the registered (correct) storage, while the engine below would
+    // be reading from the other one — so the flag would never surface and
+    // the assertion at the bottom would fail.
+    const ctx = registered.context();
+    for (const revision of registered.migrations) {
+      await revision.up(ctx, {
+        revision: { module: registered.module, id: revision.id, name: revision.name },
+        secrets: {} as any,
+      });
+    }
+    resolveReady();
+
+    await extension.key.store.ready;
+
+    // The end-to-end assertion: the flag written by the migration reaches
+    // the extension's reactive `keys`, proving the engine actually reads
+    // from the same MMKV instance the migration rewrote.
+    const flagged = extension.keys.find((k) => k.id === "pk1");
+    expect(flagged?.metadata?.migration).toBe(PASSKEY_MIGRATION_NEEDED);
   });
 });

--- a/keystore/react-native/src/extension.ts
+++ b/keystore/react-native/src/extension.ts
@@ -3,6 +3,8 @@ import type { LogStoreExtension } from "@algorandfoundation/log-store";
 import type { Extension, Provider } from "@algorandfoundation/wallet-provider";
 
 import { createReactNativeKeyStore } from "./engine.ts";
+import { migrations } from "./migrations/index.ts";
+import { storage as defaultStorage } from "./storage/state.ts";
 import type { ReactKeystoreOptions } from "./types.ts";
 
 /**
@@ -24,7 +26,10 @@ import type { ReactKeystoreOptions } from "./types.ts";
  * engine already exposes its `hooks` collection on the returned keystore, so the
  * extension surfaces `key.store` as-is without re-assigning it.
  *
- * @param provider - The host provider (may carry a `log` extension).
+ * @param provider - The host provider (may carry `log` and `migrations`
+ *   extensions). When a `migrations` extension is present, this package's
+ *   revisions (see `./migrations/index.ts`) are registered against it and the
+ *   engine defers hydration until they have run.
  * @param options - {@link ReactKeystoreOptions}. `options.keystore.store` and
  *   `options.keystore.hooks` are required; the crypto bindings are required only
  *   when the extension builds the engine itself.
@@ -32,6 +37,18 @@ import type { ReactKeystoreOptions } from "./types.ts";
  * @returns The {@link KeyStoreExtension} surface with reactive `keys`/`status`
  *   and the `key.store` keystore API (which already exposes `hooks` when the
  *   engine was built with them).
+ *
+ * @remarks
+ * Migration registration (`migrationsApi?.register(...)`) always runs,
+ * regardless of which code path above supplies the keystore API — but the
+ * `before` gate (which sequences `createReactNativeKeyStore`'s hydration
+ * behind `provider.migrations?.ready`) only exists on the engine-building
+ * path. When `options.api.keystore` is injected, `createReactNativeKeyStore`
+ * is never called, so that gate never exists: this package's migrations
+ * still run against `options.keystore.storage ?? defaultStorage`, but with no
+ * ordering guarantee relative to the injected backend. A consumer who injects
+ * `options.api.keystore` owns sequencing the injected backend against
+ * `provider.migrations.ready` itself.
  *
  * @example
  * ```typescript
@@ -52,10 +69,35 @@ import type { ReactKeystoreOptions } from "./types.ts";
  * ```
  */
 export const WithKeyStore: Extension<KeyStoreExtension> = (
-  _provider: Provider<any> & Partial<LogStoreExtension>,
+  provider: Provider<any> & Partial<LogStoreExtension>,
   options: ReactKeystoreOptions,
 ) => {
   const keyStore = options.keystore.store;
+  const storage = options.keystore.storage ?? defaultStorage;
+
+  // Opt-in: a no-op unless the provider carries a migrations extension. That
+  // is silent by design (see `register`'s no-op contract), but silent opt-in
+  // for a whole feature is easy to misconfigure — `WithMigrations` must be
+  // installed *first* in the extensions array, and getting that wrong yields
+  // no registration, no gate and no error. This can't be detected from inside
+  // `WithMigrations` itself (it runs before every other extension), so the
+  // cheap check lives here instead: warn once, when there is something this
+  // package would have registered.
+  const migrationsApi = (provider as any)?.migrations;
+  if (!migrationsApi && migrations.length > 0) {
+    provider.log?.warn(
+      "@algorandfoundation/react-native-keystore has data migrations to run, but no " +
+        "`migrations` extension is installed on the provider. Add `WithMigrations` from " +
+        '"@algorandfoundation/provider-migrations" — first — in the provider\'s extensions ' +
+        "array, or these migrations will never run.",
+      { module: "@algorandfoundation/react-native-keystore" },
+    );
+  }
+  migrationsApi?.register({
+    module: "@algorandfoundation/react-native-keystore",
+    context: () => storage,
+    migrations,
+  });
 
   // Single source of the API: use an injected backend when present, otherwise
   // build the shared React Native engine and let it own every operation. The
@@ -67,9 +109,10 @@ export const WithKeyStore: Extension<KeyStoreExtension> = (
       store: keyStore,
       subtle: options.keystore.subtle as SubtleCrypto,
       shims: options.keystore.shims,
-      storage: options.keystore.storage,
+      storage,
       hooks: options.keystore.hooks,
       authentication: options.keystore.authentication,
+      before: migrationsApi?.ready,
     });
 
   return {

--- a/keystore/react-native/src/migrations/0001-flag-legacy-passkeys.test.ts
+++ b/keystore/react-native/src/migrations/0001-flag-legacy-passkeys.test.ts
@@ -1,0 +1,66 @@
+import { createSecretScratch } from "@algorandfoundation/provider-migrations";
+import { assertIdempotent } from "@algorandfoundation/provider-migrations/testing";
+import { describe, expect, it } from "vitest";
+import { memoryStorage, seedLegacyPasskey } from "../storage/__fixtures__.ts";
+import { PASSKEY_MIGRATION_NEEDED } from "../storage/driver.ts";
+import { migration } from "./0001-flag-legacy-passkeys.ts";
+
+describe("revision 0001 — flag-legacy-passkeys", () => {
+  it("is revision 1", () => {
+    expect(migration.id).toBe(1);
+    expect(migration.name).toBe("flag-legacy-passkeys");
+  });
+
+  it("flags a legacy passkey in place", async () => {
+    const storage = memoryStorage();
+    seedLegacyPasskey(storage, "pk1");
+
+    const { scratch, wipeAll } = createSecretScratch();
+    try {
+      await migration.up(storage, {
+        revision: { module: "test", id: 1, name: "flag-legacy-passkeys" },
+        secrets: scratch,
+      });
+    } finally {
+      wipeAll();
+    }
+
+    const stored = JSON.parse(storage.getString("k/pk1") as string);
+    expect(stored.metadata.migration).toBe(PASSKEY_MIGRATION_NEEDED);
+    expect(stored.metadata.origin).toBe("https://example.com");
+    expect(stored.metadata.userHandle).toBe("user-123");
+    expect(storage.getString("k/pk1:needs-migration")).toBeUndefined();
+  });
+
+  it("is idempotent", async () => {
+    await assertIdempotent({
+      migration,
+      context: () => {
+        const storage = memoryStorage();
+        seedLegacyPasskey(storage, "pk1");
+        storage.set(
+          "k/pk2",
+          JSON.stringify({
+            id: "pk2",
+            type: "hd-derived-p256",
+            algorithm: "P256",
+            extractable: false,
+            keyUsages: ["sign", "verify"],
+            metadata: { storage: "none", scheme: "pbkdf2-p256", origin: "o", userHandle: "u" },
+            version: 1,
+          }),
+        );
+        return storage;
+      },
+      snapshot: (storage) => (storage as ReturnType<typeof memoryStorage>).entries(),
+    });
+  });
+
+  it("is a no-op on empty storage", async () => {
+    await assertIdempotent({
+      migration,
+      context: () => memoryStorage(),
+      snapshot: (storage) => (storage as ReturnType<typeof memoryStorage>).entries(),
+    });
+  });
+});

--- a/keystore/react-native/src/migrations/0001-flag-legacy-passkeys.ts
+++ b/keystore/react-native/src/migrations/0001-flag-legacy-passkeys.ts
@@ -1,0 +1,24 @@
+import type { Migration } from "@algorandfoundation/provider-migrations";
+import { migrateLegacyPasskeys } from "../storage/driver.ts";
+import type { KeychainStorage } from "../storage/driver.ts";
+
+/**
+ * Flags legacy passkeys — those derived from the XHD root before the
+ * deterministic-P256 split — as needing migration.
+ *
+ * Previously this ran unconditionally on every engine start. As a tracked
+ * revision it runs once, and the ledger records that it has.
+ *
+ * The scan is metadata-only (`k/` bucket): no material is decrypted and no
+ * biometric prompt fires. It is idempotent — an already-flagged record and a
+ * new-scheme passkey are both skipped — and a no-op on empty storage.
+ */
+export const migration: Migration<KeychainStorage> = {
+  id: 1,
+  name: "flag-legacy-passkeys",
+  up: (storage: KeychainStorage): void => {
+    migrateLegacyPasskeys(storage);
+  },
+};
+
+export default migration;

--- a/keystore/react-native/src/migrations/index.test.ts
+++ b/keystore/react-native/src/migrations/index.test.ts
@@ -1,0 +1,15 @@
+import { validateMigrations } from "@algorandfoundation/provider-migrations";
+import { describe, expect, it } from "vitest";
+import { migrations } from "./index.ts";
+
+describe("migrations manifest", () => {
+  it("has valid, ascending revision ids", () => {
+    expect(() =>
+      validateMigrations(migrations, "@algorandfoundation/react-native-keystore"),
+    ).not.toThrow();
+  });
+
+  it("declares at least revision 1", () => {
+    expect(migrations.map((m) => m.id)).toContain(1);
+  });
+});

--- a/keystore/react-native/src/migrations/index.ts
+++ b/keystore/react-native/src/migrations/index.ts
@@ -1,0 +1,11 @@
+import type { Migration } from "@algorandfoundation/provider-migrations";
+import type { KeychainStorage } from "../storage/driver.ts";
+import { migration as r0001 } from "./0001-flag-legacy-passkeys.ts";
+
+/**
+ * Every revision this package declares, ascending by id.
+ *
+ * Registered with the provider by {@link import("../extension.ts").WithKeyStore}
+ * when a migrations extension is present.
+ */
+export const migrations: readonly Migration<KeychainStorage>[] = [r0001];

--- a/keystore/react-native/src/storage/__fixtures__.ts
+++ b/keystore/react-native/src/storage/__fixtures__.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared test fixtures for the Keychain/MMKV storage surface.
+ *
+ * Excluded from the published build (see `tsconfig.build.json`) — these are
+ * test-only helpers and must never ship in `dist/`.
+ */
+
+import type { KeychainStorage } from "./driver.ts";
+
+/** A fresh in-memory MMKV-style store per test (real Keychain master is mocked). */
+export function memoryStorage(): KeychainStorage & { entries(): [string, string][] } {
+  const map = new Map<string, string>();
+  return {
+    getString: (key) => map.get(key),
+    set: (key, value) => {
+      map.set(key, value);
+    },
+    remove: (key) => {
+      map.delete(key);
+    },
+    getAllKeys: () => [...map.keys()],
+    entries: () => [...map.entries()],
+  };
+}
+
+/** Seeds a legacy passkey metadata record (pre-dp256-split, no `scheme`). */
+export function seedLegacyPasskey(storage: KeychainStorage, id: string): void {
+  storage.set(
+    `k/${id}`,
+    JSON.stringify({
+      id,
+      type: "hd-derived-p256",
+      algorithm: "P256",
+      extractable: false,
+      keyUsages: ["sign", "verify"],
+      metadata: {
+        storage: "none",
+        origin: "https://example.com",
+        userHandle: "user-123",
+        counter: 0,
+        parentKeyId: "xhd-root-1",
+      },
+      version: 1,
+    }),
+  );
+}

--- a/keystore/react-native/tsconfig.build.json
+++ b/keystore/react-native/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "**/*.test.ts", "**/*.bench.ts"]
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.bench.ts", "**/__fixtures__.ts"]
 }

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,199 @@
+# `@algorandfoundation/provider-migrations`
+
+Revision-tracked data migrations for Wallet Provider extensions.
+
+Packages in this repository publish breaking changes often. When a breaking
+change alters the shape of _persisted_ data, this engine lets the package ship a
+versioned migration alongside it, so consuming applications converge instead of
+losing data.
+
+## Using it in an application
+
+`WithMigrations` must be **first** in the extensions array, so later extensions
+can register with it.
+
+```typescript
+import { Provider } from "@algorandfoundation/wallet-provider";
+import { WithMigrations, keyValueLedger } from "@algorandfoundation/provider-migrations";
+
+const MyProvider = Provider.withExtensions([WithMigrations, WithKeyStore]);
+
+const provider = new MyProvider(
+  { id: "wallet", name: "Wallet" },
+  {
+    migrations: {
+      ledger: keyValueLedger({
+        get: (k) => localStorage.getItem(k),
+        set: (k, v) => localStorage.setItem(k, v),
+      }),
+    },
+    keystore: { store, hooks },
+  },
+);
+
+await provider.migrations.ready;
+```
+
+If `WithMigrations` is absent, `provider.migrations` is `undefined` and every
+`register` call is a no-op. That is the opt-in mechanism.
+
+Pass `migrations: { autoRun: false }` to defer the run, then call
+`provider.migrations.run()` yourself — useful when migrations must wait behind a
+splash screen or an unlock.
+
+## Adding a migration to a package
+
+Keep revisions in `src/migrations/`, one file per revision, and maintain a typed
+barrel.
+
+```typescript
+// src/migrations/0001-add-scheme-field.ts
+import type { Migration } from "@algorandfoundation/provider-migrations";
+import type { MyStorage } from "../storage/driver.ts";
+
+export const migration: Migration<MyStorage> = {
+  id: 1,
+  name: "add-scheme-field",
+  up: (storage) => {
+    for (const record of readAll(storage)) {
+      if (record.scheme) continue; // already migrated
+      write(storage, { ...record, scheme: "v2" });
+    }
+  },
+};
+```
+
+```typescript
+// src/migrations/index.ts
+import type { Migration } from "@algorandfoundation/provider-migrations";
+import type { MyStorage } from "../storage/driver.ts";
+import { migration as r0001 } from "./0001-add-scheme-field.ts";
+
+export const migrations: readonly Migration<MyStorage>[] = [r0001];
+```
+
+Then register from your extension, using the optional-dependency probe:
+
+```typescript
+provider.migrations?.register({
+  module: "@algorandfoundation/my-package",
+  context: () => storage,
+  migrations,
+});
+```
+
+Take this package as a **devDependency plus an optional peerDependency**. Only
+types are imported, and `verbatimModuleSyntax` erases them, so there is no
+runtime dependency.
+
+## Migrations in your own application extensions
+
+Nothing about the engine is specific to packages in this repository. An
+application that writes its own extensions registers them exactly the same way —
+`register` accepts any module id and any context type.
+
+```typescript
+import type { Migration } from "@algorandfoundation/provider-migrations";
+import { migrations } from "./migrations/index.ts";
+
+export const WithWatchedAccounts = (provider: any, options: MyOptions) => {
+  const storage = options.watched.storage;
+
+  provider.migrations?.register({
+    module: "com.mycompany.wallet/watched-accounts",
+    context: () => storage,
+    migrations,
+  });
+
+  return {
+    /* your API */
+  };
+};
+```
+
+Three requirements:
+
+- `WithMigrations` is **first** in `EXTENSIONS`, and your extension comes after
+  it. Otherwise `provider.migrations` does not exist yet when your extension
+  runs, `register` no-ops, and your migrations silently never run.
+- Your `module` id is unique and stable. It is the ledger key, so renaming it
+  later makes the engine believe the module has never migrated. A reverse-DNS
+  string or your package name works; just do not reuse an id a library already
+  claims.
+- Applications take this package as a normal **dependency**, not the
+  devDependency + optional peer arrangement libraries use — an application
+  imports `WithMigrations` and a ledger as values, not just types.
+
+### Ordering is positional
+
+Modules run sequentially in registration order, which is extension order. There
+is no declared dependency between modules. If one of your migrations must run
+after a library's — say it reads records the keystore migration reshapes — place
+your extension after that library's in the array. Getting this wrong produces no
+error, so it is worth a comment next to the array.
+
+### Baselining over an existing migration system
+
+If you already migrate data with your own mechanism, read this before adopting.
+
+An absent ledger entry means revision zero, so the engine runs **every** revision
+a module declares. Port your existing migrations and the first launch re-applies
+all of them to data they have already been applied to. That is safe if each is
+idempotent — which the engine requires anyway — but hand-rolled migrations often
+are not, so do not assume it.
+
+The ledger is yours, and `write` is public, so stamp it before constructing the
+provider:
+
+```typescript
+const ledger = keyValueLedger(kv);
+const state = await ledger.read();
+
+if (!state["com.mycompany.wallet/watched-accounts"]) {
+  const alreadyApplied = readMyLegacyMigrationState(); // your current mechanism
+  if (alreadyApplied > 0) {
+    await ledger.write("com.mycompany.wallet/watched-accounts", {
+      id: alreadyApplied,
+      name: "baseline-from-legacy-migrations",
+      appliedAt: new Date().toISOString(),
+    });
+  }
+}
+
+const provider = new MyProvider(config, { migrations: { ledger } /* ... */ });
+await provider.migrations.ready;
+```
+
+Number your ported revisions to match the sequence your old system used and the
+engine resumes exactly where it left off. A fresh install has no legacy state,
+gets no baseline entry, and correctly runs everything from revision 1.
+
+Run `assertIdempotent` over each ported revision regardless. Migrations written
+against a run-once mechanism are the most likely in any codebase to break when
+run twice, and the baseline above is the only thing standing between them and a
+re-run.
+
+## Rules for writing a migration
+
+1. **Idempotent.** Running twice must converge to the same state. Assert it with
+   `assertIdempotent` from `@algorandfoundation/provider-migrations/testing`.
+2. **A no-op on empty data.** A fresh install runs every revision from zero.
+3. **Copy, verify, delete — never move.** Write the new location, verify it reads
+   back, and only then delete the old one. A crash then leaves both copies and
+   re-running converges.
+4. **Never put key material in an error message.** Failures are recorded verbatim
+   in the report.
+5. **Use `utils.secrets` for material in flight**, never a bare local variable.
+
+## Guarding revision ids
+
+There is no generator. Assert your own barrel in a unit test:
+
+```typescript
+import { validateMigrations } from "@algorandfoundation/provider-migrations";
+import { migrations } from "./index.ts";
+
+it("has a valid manifest", () => {
+  expect(() => validateMigrations(migrations, "@algorandfoundation/my-package")).not.toThrow();
+});
+```

--- a/migrations/package.json
+++ b/migrations/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@algorandfoundation/provider-migrations",
+  "version": "0.0.0",
+  "description": "Revision-tracked data migrations for Wallet Provider extensions.",
+  "license": "Apache-2.0",
+  "author": "Algorand Foundation",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/algorandfoundation/wallet-provider-extensions.git",
+    "directory": "migrations"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./testing": {
+      "types": "./dist/testing.d.ts",
+      "import": "./dist/testing.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist coverage node_modules docs",
+    "docs": "typedoc",
+    "test": "vitest run",
+    "test:cov": "vitest run --coverage",
+    "release": "package-releaser",
+    "release:dry-run": "package-releaser --dry-run"
+  },
+  "dependencies": {
+    "@algorandfoundation/wallet-provider": "catalog:"
+  },
+  "devDependencies": {
+    "@algorandfoundation/package-releaser": "workspace:^",
+    "before-after-hook": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "before-after-hook": "catalog:"
+  }
+}

--- a/migrations/src/apply.test.ts
+++ b/migrations/src/apply.test.ts
@@ -1,0 +1,778 @@
+import { describe, expect, it } from "vitest";
+import Hook from "before-after-hook";
+import {
+  InvalidMigrationsError,
+  MigrationFailedError,
+  SecretScratchDisposedError,
+} from "./errors.ts";
+import { applyMigrations, validateMigrations } from "./apply.ts";
+import { keyValueLedger, memoryLedger } from "./ledger.ts";
+import type {
+  KeyValueStore,
+  Migration,
+  MigrationLedger,
+  MigrationModule,
+  Revision,
+} from "./types.ts";
+
+/** Alias for the scratch captured out of a migration, for lifetime assertions. */
+type MigrationUtilsCapture = Parameters<Migration<unknown>["up"]>[1]["secrets"];
+
+/** Builds a no-op revision with the given id. */
+function rev(id: number, name = `rev-${id}`): Migration<unknown> {
+  return { id, name, up: () => undefined };
+}
+
+describe("validateMigrations", () => {
+  it("accepts an empty manifest", () => {
+    expect(() => validateMigrations([])).not.toThrow();
+  });
+
+  it("accepts strictly ascending ids", () => {
+    expect(() => validateMigrations([rev(1), rev(2), rev(7)])).not.toThrow();
+  });
+
+  it("rejects a zero id", () => {
+    expect(() => validateMigrations([rev(0)])).toThrow(InvalidMigrationsError);
+  });
+
+  it("rejects a negative id", () => {
+    expect(() => validateMigrations([rev(-1)])).toThrow(InvalidMigrationsError);
+  });
+
+  it("rejects a non-integer id", () => {
+    expect(() => validateMigrations([rev(1.5)])).toThrow(InvalidMigrationsError);
+  });
+
+  it("rejects duplicate ids", () => {
+    expect(() => validateMigrations([rev(1), rev(1)])).toThrow(InvalidMigrationsError);
+  });
+
+  it("rejects out-of-order ids", () => {
+    expect(() => validateMigrations([rev(2), rev(1)])).toThrow(InvalidMigrationsError);
+  });
+
+  it("names the module in the message", () => {
+    expect(() => validateMigrations([rev(1), rev(1)], "@scope/pkg")).toThrow(/@scope\/pkg/);
+  });
+});
+
+/** Records the order in which revisions ran, for ordering assertions. */
+function recorder(): { order: string[]; rev: (id: number, module?: string) => Migration<unknown> } {
+  const order: string[] = [];
+  return {
+    order,
+    rev: (id, module = "m") => ({
+      id,
+      name: `rev-${id}`,
+      up: () => {
+        order.push(`${module}:${id}`);
+      },
+    }),
+  };
+}
+
+/** Wraps a ledger, recording the sequence of writes as they happen. */
+function tracingLedger(inner: MigrationLedger): {
+  ledger: MigrationLedger;
+  writes: { module: string; revision: Revision }[];
+} {
+  const writes: { module: string; revision: Revision }[] = [];
+  return {
+    writes,
+    ledger: {
+      read: () => inner.read(),
+      async write(module, revision) {
+        writes.push({ module, revision });
+        await inner.write(module, revision);
+      },
+    },
+  };
+}
+
+describe("applyMigrations", () => {
+  it("applies every revision ascending from an empty ledger", async () => {
+    const { order, rev } = recorder();
+    const registry: MigrationModule<unknown>[] = [
+      { module: "m", context: () => ({}), migrations: [rev(1), rev(2), rev(3)] },
+    ];
+
+    const report = await applyMigrations({ registry, ledger: memoryLedger() });
+
+    expect(order).toEqual(["m:1", "m:2", "m:3"]);
+    expect(report.applied.map((a) => a.id)).toEqual([1, 2, 3]);
+    expect(report.failed).toEqual([]);
+  });
+
+  it("resumes from the ledger, skipping applied revisions", async () => {
+    const { order, rev } = recorder();
+    const ledger = memoryLedger({
+      m: { id: 2, name: "rev-2", appliedAt: "2026-01-01T00:00:00.000Z" },
+    });
+    const registry: MigrationModule<unknown>[] = [
+      { module: "m", context: () => ({}), migrations: [rev(1), rev(2), rev(3)] },
+    ];
+
+    const report = await applyMigrations({ registry, ledger });
+
+    expect(order).toEqual(["m:3"]);
+    expect(report.applied.map((a) => a.id)).toEqual([3]);
+  });
+
+  it("does nothing when the ledger is already current", async () => {
+    const { order, rev } = recorder();
+    const ledger = memoryLedger({
+      m: { id: 2, name: "rev-2", appliedAt: "2026-01-01T00:00:00.000Z" },
+    });
+
+    const report = await applyMigrations({
+      registry: [{ module: "m", context: () => ({}), migrations: [rev(1), rev(2)] }],
+      ledger,
+    });
+
+    expect(order).toEqual([]);
+    expect(report.applied).toEqual([]);
+  });
+
+  it("does not resolve the context when nothing is pending", async () => {
+    let resolved = 0;
+    const ledger = memoryLedger({
+      m: { id: 1, name: "rev-1", appliedAt: "2026-01-01T00:00:00.000Z" },
+    });
+
+    await applyMigrations({
+      registry: [
+        {
+          module: "m",
+          context: () => {
+            resolved += 1;
+            return {};
+          },
+          migrations: [{ id: 1, name: "rev-1", up: () => undefined }],
+        },
+      ],
+      ledger,
+    });
+
+    expect(resolved).toBe(0);
+  });
+
+  it("resolves the context exactly once for a module with pending revisions", async () => {
+    let resolved = 0;
+    const { rev } = recorder();
+
+    await applyMigrations({
+      registry: [
+        {
+          module: "m",
+          context: () => {
+            resolved += 1;
+            return {};
+          },
+          migrations: [rev(1), rev(2)],
+        },
+      ],
+      ledger: memoryLedger(),
+    });
+
+    expect(resolved).toBe(1);
+  });
+
+  it("passes the resolved context to every revision", async () => {
+    const context = { handle: "storage" };
+    const seen: unknown[] = [];
+
+    await applyMigrations({
+      registry: [
+        {
+          module: "m",
+          context: () => context,
+          migrations: [
+            { id: 1, name: "a", up: (ctx) => void seen.push(ctx) },
+            { id: 2, name: "b", up: (ctx) => void seen.push(ctx) },
+          ],
+        },
+      ],
+      ledger: memoryLedger(),
+    });
+
+    expect(seen).toEqual([context, context]);
+  });
+
+  it("awaits an async context factory and an async `up`", async () => {
+    const order: string[] = [];
+
+    await applyMigrations({
+      registry: [
+        {
+          module: "m",
+          context: async () => {
+            order.push("context");
+            return {};
+          },
+          migrations: [
+            {
+              id: 1,
+              name: "a",
+              up: async () => {
+                order.push("up");
+              },
+            },
+          ],
+        },
+      ],
+      ledger: memoryLedger(),
+    });
+
+    expect(order).toEqual(["context", "up"]);
+  });
+
+  it("writes the ledger after each revision, not once at the end", async () => {
+    const { ledger, writes } = tracingLedger(memoryLedger());
+    const seenDuringRun: number[] = [];
+
+    await applyMigrations({
+      registry: [
+        {
+          module: "m",
+          context: () => ({}),
+          migrations: [
+            { id: 1, name: "a", up: () => void seenDuringRun.push(writes.length) },
+            { id: 2, name: "b", up: () => void seenDuringRun.push(writes.length) },
+            { id: 3, name: "c", up: () => void seenDuringRun.push(writes.length) },
+          ],
+        },
+      ],
+      ledger,
+    });
+
+    // Revision N sees exactly N-1 completed writes: each is recorded before the
+    // next begins, which is what makes a killed run resumable.
+    expect(seenDuringRun).toEqual([0, 1, 2]);
+    expect(writes.map((w) => w.revision.id)).toEqual([1, 2, 3]);
+  });
+
+  it("records the revision name and an ISO-8601 timestamp in the ledger", async () => {
+    const ledger = memoryLedger();
+
+    await applyMigrations({
+      registry: [
+        {
+          module: "m",
+          context: () => ({}),
+          migrations: [{ id: 4, name: "split-scheme", up: () => undefined }],
+        },
+      ],
+      ledger,
+    });
+
+    const entry = (await ledger.read())["m"];
+    expect(entry?.id).toBe(4);
+    expect(entry?.name).toBe("split-scheme");
+    expect(entry?.appliedAt).toMatch(/^\d{4}-\d{2}-\d{2}T[\d:.]+Z$/);
+  });
+
+  it("runs modules sequentially in registration order", async () => {
+    const { order, rev } = recorder();
+
+    await applyMigrations({
+      registry: [
+        { module: "a", context: () => ({}), migrations: [rev(1, "a"), rev(2, "a")] },
+        { module: "b", context: () => ({}), migrations: [rev(1, "b")] },
+      ],
+      ledger: memoryLedger(),
+    });
+
+    expect(order).toEqual(["a:1", "a:2", "b:1"]);
+  });
+
+  it("tracks each module's revision independently", async () => {
+    const ledger = memoryLedger({
+      a: { id: 1, name: "rev-1", appliedAt: "2026-01-01T00:00:00.000Z" },
+    });
+    const { order, rev } = recorder();
+
+    await applyMigrations({
+      registry: [
+        { module: "a", context: () => ({}), migrations: [rev(1, "a"), rev(2, "a")] },
+        { module: "b", context: () => ({}), migrations: [rev(1, "b")] },
+      ],
+      ledger,
+    });
+
+    expect(order).toEqual(["a:2", "b:1"]);
+  });
+
+  it("gives each revision its identity in utils", async () => {
+    const seen: unknown[] = [];
+
+    await applyMigrations({
+      registry: [
+        {
+          module: "@scope/pkg",
+          context: () => ({}),
+          migrations: [
+            { id: 7, name: "seven", up: (_ctx, utils) => void seen.push(utils.revision) },
+          ],
+        },
+      ],
+      ledger: memoryLedger(),
+    });
+
+    expect(seen).toEqual([{ module: "@scope/pkg", id: 7, name: "seven" }]);
+  });
+});
+
+describe("applyMigrations — failures", () => {
+  it("rejects with MigrationFailedError carrying the report", async () => {
+    const boom = new Error("boom");
+    const promise = applyMigrations({
+      registry: [
+        {
+          module: "m",
+          context: () => ({}),
+          migrations: [
+            {
+              id: 1,
+              name: "explodes",
+              up: () => {
+                throw boom;
+              },
+            },
+          ],
+        },
+      ],
+      ledger: memoryLedger(),
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(MigrationFailedError);
+    await promise.catch((error: MigrationFailedError) => {
+      expect(error.report.failed).toEqual([{ module: "m", id: 1, name: "explodes", error: boom }]);
+    });
+  });
+
+  it("halts the failing module at the failing revision", async () => {
+    const order: string[] = [];
+    const promise = applyMigrations({
+      registry: [
+        {
+          module: "m",
+          context: () => ({}),
+          migrations: [
+            { id: 1, name: "a", up: () => void order.push("a") },
+            {
+              id: 2,
+              name: "b",
+              up: () => {
+                throw new Error("boom");
+              },
+            },
+            { id: 3, name: "c", up: () => void order.push("c") },
+          ],
+        },
+      ],
+      ledger: memoryLedger(),
+    });
+
+    await expect(promise).rejects.toThrow();
+    expect(order).toEqual(["a"]);
+  });
+
+  it("leaves the ledger at the last successful revision", async () => {
+    const ledger = memoryLedger();
+    const promise = applyMigrations({
+      registry: [
+        {
+          module: "m",
+          context: () => ({}),
+          migrations: [
+            { id: 1, name: "a", up: () => undefined },
+            {
+              id: 2,
+              name: "b",
+              up: () => {
+                throw new Error("boom");
+              },
+            },
+          ],
+        },
+      ],
+      ledger,
+    });
+
+    await expect(promise).rejects.toThrow();
+    expect((await ledger.read())["m"]?.id).toBe(1);
+  });
+
+  it("still runs later modules after one fails", async () => {
+    const order: string[] = [];
+    const promise = applyMigrations({
+      registry: [
+        {
+          module: "a",
+          context: () => ({}),
+          migrations: [
+            {
+              id: 1,
+              name: "boom",
+              up: () => {
+                throw new Error("boom");
+              },
+            },
+          ],
+        },
+        {
+          module: "b",
+          context: () => ({}),
+          migrations: [{ id: 1, name: "ok", up: () => void order.push("b:1") }],
+        },
+      ],
+      ledger: memoryLedger(),
+    });
+
+    await expect(promise).rejects.toThrow();
+    expect(order).toEqual(["b:1"]);
+  });
+
+  it("reports an applied revision alongside a failure", async () => {
+    const promise = applyMigrations({
+      registry: [
+        {
+          module: "a",
+          context: () => ({}),
+          migrations: [
+            {
+              id: 1,
+              name: "boom",
+              up: () => {
+                throw new Error("boom");
+              },
+            },
+          ],
+        },
+        {
+          module: "b",
+          context: () => ({}),
+          migrations: [{ id: 1, name: "ok", up: () => undefined }],
+        },
+      ],
+      ledger: memoryLedger(),
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(MigrationFailedError);
+    await promise.catch((error: MigrationFailedError) => {
+      expect(error.report.applied).toEqual([{ module: "b", id: 1, name: "ok" }]);
+      expect(error.report.failed).toHaveLength(1);
+    });
+  });
+
+  it("records an invalid manifest as a module-level failure without a revision", async () => {
+    const promise = applyMigrations({
+      registry: [
+        { module: "a", context: () => ({}), migrations: [rev(2), rev(1)] },
+        { module: "b", context: () => ({}), migrations: [rev(1)] },
+      ],
+      ledger: memoryLedger(),
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(MigrationFailedError);
+    await promise.catch((error: MigrationFailedError) => {
+      expect(error.report.failed).toHaveLength(1);
+      expect(error.report.failed[0]?.module).toBe("a");
+      expect(error.report.failed[0]?.id).toBeUndefined();
+      expect(error.report.applied.map((a) => a.module)).toEqual(["b"]);
+    });
+  });
+
+  it("records a duplicate module registration as a failure", async () => {
+    const promise = applyMigrations({
+      registry: [
+        { module: "a", context: () => ({}), migrations: [rev(1)] },
+        { module: "a", context: () => ({}), migrations: [rev(1)] },
+      ],
+      ledger: memoryLedger(),
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(MigrationFailedError);
+    await promise.catch((error: MigrationFailedError) => {
+      expect(error.report.failed).toHaveLength(1);
+      expect(error.report.failed[0]?.error.message).toMatch(/registered more than once/);
+    });
+  });
+
+  it("records a throwing context factory as a module-level failure", async () => {
+    const promise = applyMigrations({
+      registry: [
+        {
+          module: "a",
+          context: () => {
+            throw new Error("cannot open storage");
+          },
+          migrations: [rev(1)],
+        },
+      ],
+      ledger: memoryLedger(),
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(MigrationFailedError);
+    await promise.catch((error: MigrationFailedError) => {
+      expect(error.report.failed[0]?.id).toBeUndefined();
+      expect(error.report.failed[0]?.error.message).toBe("cannot open storage");
+    });
+  });
+});
+
+describe("applyMigrations — ledger ahead of code", () => {
+  it("reports a downgrade without throwing", async () => {
+    const ledger = memoryLedger({
+      m: { id: 5, name: "rev-5", appliedAt: "2026-01-01T00:00:00.000Z" },
+    });
+    const { order, rev: makeRev } = recorder();
+
+    const report = await applyMigrations({
+      registry: [{ module: "m", context: () => ({}), migrations: [makeRev(1), makeRev(2)] }],
+      ledger,
+    });
+
+    expect(report.ahead).toEqual([{ module: "m", ledgerRevision: 5, latestKnown: 2 }]);
+    expect(report.failed).toEqual([]);
+    expect(order).toEqual([]);
+  });
+
+  it("warns through the logger when one is supplied", async () => {
+    const warnings: string[] = [];
+    const ledger = memoryLedger({
+      m: { id: 5, name: "rev-5", appliedAt: "2026-01-01T00:00:00.000Z" },
+    });
+
+    await applyMigrations({
+      registry: [{ module: "m", context: () => ({}), migrations: [rev(1)] }],
+      ledger,
+      log: {
+        info: () => undefined,
+        warn: (message) => void warnings.push(message),
+        error: () => undefined,
+      },
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/ahead/);
+  });
+});
+
+describe("applyMigrations — hooks", () => {
+  it("fires once per revision with the module and revision only", async () => {
+    const hooks = new Hook.Collection<any>();
+    const payloads: unknown[] = [];
+    hooks.before("migrate", (options: unknown) => {
+      payloads.push(JSON.parse(JSON.stringify(options)));
+    });
+
+    await applyMigrations({
+      registry: [
+        {
+          module: "@scope/pkg",
+          context: () => ({ secret: "storage handle" }),
+          migrations: [
+            { id: 1, name: "a", up: () => undefined },
+            { id: 2, name: "b", up: () => undefined },
+          ],
+        },
+      ],
+      ledger: memoryLedger(),
+      hooks,
+    });
+
+    expect(payloads).toEqual([
+      { module: "@scope/pkg", revision: { id: 1, name: "a" } },
+      { module: "@scope/pkg", revision: { id: 2, name: "b" } },
+    ]);
+  });
+
+  it("does not expose the context or the scratch to hooks", async () => {
+    const hooks = new Hook.Collection<any>();
+    const keys: string[][] = [];
+    hooks.before("migrate", (options: Record<string, unknown>) => {
+      keys.push(Object.keys(options).sort());
+    });
+
+    await applyMigrations({
+      registry: [
+        {
+          module: "m",
+          context: () => ({ handle: "secret" }),
+          migrations: [{ id: 1, name: "a", up: () => undefined }],
+        },
+      ],
+      ledger: memoryLedger(),
+      hooks,
+    });
+
+    expect(keys).toEqual([["module", "revision"]]);
+  });
+
+  it("surfaces a hook error as a revision failure", async () => {
+    const hooks = new Hook.Collection<any>();
+    hooks.before("migrate", () => {
+      throw new Error("hook rejected");
+    });
+
+    const promise = applyMigrations({
+      registry: [
+        {
+          module: "m",
+          context: () => ({}),
+          migrations: [{ id: 1, name: "a", up: () => undefined }],
+        },
+      ],
+      ledger: memoryLedger(),
+      hooks,
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(MigrationFailedError);
+    await promise.catch((error: MigrationFailedError) => {
+      expect(error.report.failed[0]?.error.message).toBe("hook rejected");
+    });
+  });
+});
+
+describe("applyMigrations — scratch lifecycle", () => {
+  it("wipes the scratch after a successful revision", async () => {
+    let captured: MigrationUtilsCapture | undefined;
+
+    await applyMigrations({
+      registry: [
+        {
+          module: "m",
+          context: () => ({}),
+          migrations: [
+            {
+              id: 1,
+              name: "a",
+              up: (_ctx, utils) => {
+                utils.secrets.put("seed", new Uint8Array([1, 2, 3]));
+                captured = utils.secrets;
+              },
+            },
+          ],
+        },
+      ],
+      ledger: memoryLedger(),
+    });
+
+    expect(() => captured?.has("seed")).toThrow(SecretScratchDisposedError);
+  });
+
+  it("wipes the scratch when a revision throws", async () => {
+    let captured: MigrationUtilsCapture | undefined;
+    const bytes = new Uint8Array([1, 2, 3]);
+
+    const promise = applyMigrations({
+      registry: [
+        {
+          module: "m",
+          context: () => ({}),
+          migrations: [
+            {
+              id: 1,
+              name: "a",
+              up: (_ctx, utils) => {
+                utils.secrets.put("seed", bytes);
+                captured = utils.secrets;
+                throw new Error("boom");
+              },
+            },
+          ],
+        },
+      ],
+      ledger: memoryLedger(),
+    });
+
+    await expect(promise).rejects.toThrow();
+    expect(Array.from(bytes)).toEqual([0, 0, 0]);
+    expect(() => captured?.has("seed")).toThrow(SecretScratchDisposedError);
+  });
+
+  it("gives each revision its own scratch", async () => {
+    const scratches: MigrationUtilsCapture[] = [];
+
+    await applyMigrations({
+      registry: [
+        {
+          module: "m",
+          context: () => ({}),
+          migrations: [
+            { id: 1, name: "a", up: (_ctx, utils) => void scratches.push(utils.secrets) },
+            { id: 2, name: "b", up: (_ctx, utils) => void scratches.push(utils.secrets) },
+          ],
+        },
+      ],
+      ledger: memoryLedger(),
+    });
+
+    expect(scratches[0]).not.toBe(scratches[1]);
+  });
+});
+
+describe("applyMigrations — baselining an adopted module", () => {
+  const MODULE = "com.mycompany.wallet/watched-accounts";
+
+  /** A synchronous in-memory {@link KeyValueStore}, like MMKV or localStorage. */
+  function syncStore(): KeyValueStore {
+    const raw = new Map<string, string>();
+    return {
+      get: (key) => raw.get(key),
+      set: (key, value) => {
+        raw.set(key, value);
+      },
+    };
+  }
+
+  /** Revisions that record the ids that actually ran. */
+  function numbered(ids: number[], ran: number[]): Migration<unknown>[] {
+    return ids.map((id) => ({
+      id,
+      name: `rev-${id}`,
+      up: () => {
+        ran.push(id);
+      },
+    }));
+  }
+
+  // These pin down the adoption path documented in the package README: an
+  // application that already migrated its data with its own mechanism stamps
+  // the ledger before constructing the provider, so the engine resumes rather
+  // than re-running revisions against data they were already applied to.
+  it("skips revisions at or below a pre-stamped baseline", async () => {
+    const ledger = keyValueLedger(syncStore());
+    await ledger.write(MODULE, {
+      id: 3,
+      name: "baseline-from-legacy-migrations",
+      appliedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    const ran: number[] = [];
+    const report = await applyMigrations({
+      registry: [
+        { module: MODULE, context: () => ({}), migrations: numbered([1, 2, 3, 4, 5], ran) },
+      ],
+      ledger,
+    });
+
+    expect(ran).toEqual([4, 5]);
+    expect(report.applied.map((a) => a.id)).toEqual([4, 5]);
+    expect((await ledger.read())[MODULE]?.id).toBe(5);
+  });
+
+  it("runs every revision on a fresh install, where no baseline is written", async () => {
+    const ledger = keyValueLedger(syncStore());
+    const ran: number[] = [];
+
+    await applyMigrations({
+      registry: [{ module: MODULE, context: () => ({}), migrations: numbered([1, 2, 3], ran) }],
+      ledger,
+    });
+
+    expect(ran).toEqual([1, 2, 3]);
+  });
+});

--- a/migrations/src/apply.ts
+++ b/migrations/src/apply.ts
@@ -1,0 +1,192 @@
+import { InvalidMigrationsError, MigrationFailedError } from "./errors.ts";
+import { createSecretScratch } from "./secrets.ts";
+import type {
+  ApplyMigrationsOptions,
+  Migration,
+  MigrationReport,
+  MigrationUtils,
+} from "./types.ts";
+
+/** Log context tag used for every line the engine emits. */
+const LOG_CONTEXT = "@algorandfoundation/provider-migrations";
+
+/**
+ * Validates a module's manifest: every revision id must be a positive integer,
+ * unique, and strictly ascending.
+ *
+ * Exported so an adopting package can assert its own barrel in a unit test,
+ * catching a duplicate id from a bad merge in CI rather than on a device. The
+ * runner calls it for every module before executing anything.
+ *
+ * @param migrations - The module's revisions, in declaration order.
+ * @param module - The module id, used in the error message.
+ * @throws {InvalidMigrationsError} When the manifest is malformed.
+ *
+ * @example
+ * ```typescript
+ * it("has a valid manifest", () => {
+ *   expect(() => validateMigrations(migrations, "@scope/pkg")).not.toThrow();
+ * });
+ * ```
+ */
+export function validateMigrations(
+  migrations: readonly Migration<any>[],
+  module: string = "migrations",
+): void {
+  let previous = 0;
+  for (const migration of migrations) {
+    if (!Number.isInteger(migration.id) || migration.id < 1) {
+      throw new InvalidMigrationsError(
+        module,
+        `revision id must be a positive integer, got ${migration.id}`,
+      );
+    }
+    if (migration.id === previous) {
+      throw new InvalidMigrationsError(module, `duplicate revision id ${migration.id}`);
+    }
+    if (migration.id < previous) {
+      throw new InvalidMigrationsError(
+        module,
+        `revision id ${migration.id} is out of order (follows ${previous})`,
+      );
+    }
+    previous = migration.id;
+  }
+}
+
+/**
+ * Applies every pending revision across the registry.
+ *
+ * Modules run sequentially in registration order. For each module the ledger is
+ * consulted, the manifest validated, and the context resolved **only** when
+ * something is pending. Each revision runs with a fresh secret scratch that is
+ * wiped once it settles, and the ledger is written immediately after each
+ * success — never once at the end — so a killed run resumes exactly where it
+ * stopped.
+ *
+ * A failing revision halts only its own module; the ledger keeps that module's
+ * last successful revision and remaining modules still run. If anything failed,
+ * the returned promise rejects with a {@link MigrationFailedError} carrying the
+ * full report.
+ *
+ * @param options - {@link ApplyMigrationsOptions}.
+ * @returns The {@link MigrationReport} for a fully successful run.
+ * @throws {MigrationFailedError} When any module failed.
+ *
+ * @example
+ * ```typescript
+ * const report = await applyMigrations({ registry, ledger: memoryLedger() });
+ * console.log(`${report.applied.length} revisions applied`);
+ * ```
+ */
+export async function applyMigrations(options: ApplyMigrationsOptions): Promise<MigrationReport> {
+  const { registry, ledger, hooks, log } = options;
+  const report: MigrationReport = { applied: [], failed: [], ahead: [] };
+  const state = await ledger.read();
+  const seen = new Set<string>();
+
+  for (const entry of registry) {
+    const moduleId = entry.module;
+
+    if (seen.has(moduleId)) {
+      report.failed.push({
+        module: moduleId,
+        error: new InvalidMigrationsError(moduleId, "module registered more than once"),
+      });
+      continue;
+    }
+    seen.add(moduleId);
+
+    try {
+      validateMigrations(entry.migrations, moduleId);
+    } catch (error) {
+      report.failed.push({ module: moduleId, error: error as Error });
+      continue;
+    }
+
+    const current = state[moduleId]?.id ?? 0;
+    const latestKnown = entry.migrations.reduce(
+      (highest: number, migration: Migration<any>) =>
+        migration.id > highest ? migration.id : highest,
+      0,
+    );
+
+    if (current > latestKnown) {
+      report.ahead.push({ module: moduleId, ledgerRevision: current, latestKnown });
+      log?.warn(
+        `Ledger revision ${current} is ahead of the highest known revision ${latestKnown}; skipping`,
+        { module: moduleId },
+        LOG_CONTEXT,
+      );
+      continue;
+    }
+
+    const pending = entry.migrations.filter((migration) => migration.id > current);
+    if (pending.length === 0) {
+      continue;
+    }
+
+    let context: unknown;
+    try {
+      context = await entry.context();
+    } catch (error) {
+      report.failed.push({ module: moduleId, error: error as Error });
+      continue;
+    }
+
+    for (const migration of pending) {
+      const { scratch, wipeAll } = createSecretScratch();
+      const utils: MigrationUtils = {
+        revision: { module: moduleId, id: migration.id, name: migration.name },
+        secrets: scratch,
+        log,
+      };
+
+      try {
+        const invoke = async (): Promise<void> => {
+          await migration.up(context, utils);
+        };
+        if (hooks) {
+          await hooks("migrate", invoke, {
+            module: moduleId,
+            revision: { id: migration.id, name: migration.name },
+          });
+        } else {
+          await invoke();
+        }
+
+        await ledger.write(moduleId, {
+          id: migration.id,
+          name: migration.name,
+          appliedAt: new Date().toISOString(),
+        });
+        report.applied.push({ module: moduleId, id: migration.id, name: migration.name });
+        log?.info(
+          `Applied revision ${migration.id} (${migration.name})`,
+          { module: moduleId },
+          LOG_CONTEXT,
+        );
+      } catch (error) {
+        report.failed.push({
+          module: moduleId,
+          id: migration.id,
+          name: migration.name,
+          error: error as Error,
+        });
+        log?.error(
+          `Revision ${migration.id} (${migration.name}) failed`,
+          { module: moduleId },
+          LOG_CONTEXT,
+        );
+        break;
+      } finally {
+        wipeAll();
+      }
+    }
+  }
+
+  if (report.failed.length > 0) {
+    throw new MigrationFailedError(report);
+  }
+  return report;
+}

--- a/migrations/src/errors.test.ts
+++ b/migrations/src/errors.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  InvalidMigrationsError,
+  MigrationError,
+  MigrationFailedError,
+  MissingLedgerError,
+  SecretNotFoundError,
+  SecretScratchDisposedError,
+} from "./errors.ts";
+import type { MigrationReport } from "./types.ts";
+
+describe("errors", () => {
+  it("sets a distinct name on every error", () => {
+    expect(new MissingLedgerError().name).toBe("MissingLedgerError");
+    expect(new InvalidMigrationsError("m", "why").name).toBe("InvalidMigrationsError");
+    expect(new SecretScratchDisposedError().name).toBe("SecretScratchDisposedError");
+    expect(new SecretNotFoundError("label").name).toBe("SecretNotFoundError");
+  });
+
+  it("derives every error from MigrationError", () => {
+    expect(new MissingLedgerError()).toBeInstanceOf(MigrationError);
+    expect(new SecretNotFoundError("x")).toBeInstanceOf(Error);
+  });
+
+  it("names the module and the reason in an invalid-migrations message", () => {
+    const error = new InvalidMigrationsError("@scope/pkg", "duplicate revision id 2");
+    expect(error.message).toContain("@scope/pkg");
+    expect(error.message).toContain("duplicate revision id 2");
+  });
+
+  it("names the missing label in a secret-not-found message", () => {
+    expect(new SecretNotFoundError("seed").message).toContain("seed");
+  });
+
+  it("carries the report and summarises each failure", () => {
+    const report: MigrationReport = {
+      applied: [],
+      failed: [
+        { module: "@scope/a", id: 3, name: "split-scheme", error: new Error("boom") },
+        { module: "@scope/b", error: new Error("bad manifest") },
+      ],
+      ahead: [],
+    };
+    const error = new MigrationFailedError(report);
+
+    expect(error.report).toBe(report);
+    expect(error.message).toContain("@scope/a");
+    expect(error.message).toContain("3");
+    expect(error.message).toContain("split-scheme");
+    expect(error.message).toContain("boom");
+    expect(error.message).toContain("@scope/b");
+    expect(error.message).toContain("bad manifest");
+  });
+});

--- a/migrations/src/errors.ts
+++ b/migrations/src/errors.ts
@@ -1,0 +1,95 @@
+import type { MigrationReport } from "./types.ts";
+
+/**
+ * Base class for every error raised by the migrations engine.
+ */
+export class MigrationError extends Error {
+  /**
+   * @param message - The human-readable message.
+   * @param name - The concrete error name.
+   * @param cause - The underlying error, if any.
+   */
+  constructor(message: string, name: string, cause?: Error) {
+    super(message);
+    this.name = name;
+    if (cause) {
+      this.cause = cause;
+    }
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, MigrationError);
+    }
+  }
+}
+
+/**
+ * Thrown when `WithMigrations` is constructed without `options.migrations.ledger`.
+ *
+ * Defaulting silently to an in-memory ledger would make every migration re-run
+ * on every launch, forever.
+ */
+export class MissingLedgerError extends MigrationError {
+  constructor() {
+    super(
+      "WithMigrations requires `options.migrations.ledger`. Use `memoryLedger()` for tests or `keyValueLedger(kv)` for durable storage.",
+      "MissingLedgerError",
+    );
+  }
+}
+
+/**
+ * Thrown when a module's manifest is malformed: non-positive, duplicate, or
+ * out-of-order revision ids, or the same module registered twice.
+ */
+export class InvalidMigrationsError extends MigrationError {
+  /**
+   * @param module - The offending module id.
+   * @param reason - What is wrong with the manifest.
+   */
+  constructor(module: string, reason: string) {
+    super(`Invalid migrations for ${module}: ${reason}`, "InvalidMigrationsError");
+  }
+}
+
+/** Thrown when a secret scratch is used after the runner has wiped it. */
+export class SecretScratchDisposedError extends MigrationError {
+  constructor() {
+    super(
+      "This revision's secret scratch has been wiped and can no longer be used",
+      "SecretScratchDisposedError",
+    );
+  }
+}
+
+/** Thrown when reading a label that holds no secret. */
+export class SecretNotFoundError extends MigrationError {
+  /**
+   * @param label - The label that was not found.
+   */
+  constructor(label: string) {
+    super(`No secret stored under label: ${label}`, "SecretNotFoundError");
+  }
+}
+
+/**
+ * Aggregate thrown at the end of a run in which at least one module failed.
+ * Carries the full {@link MigrationReport}, including whatever succeeded.
+ */
+export class MigrationFailedError extends MigrationError {
+  /** The full report for the run, including successful revisions. */
+  readonly report: MigrationReport;
+
+  /**
+   * @param report - The report for the completed run.
+   */
+  constructor(report: MigrationReport) {
+    const summary = report.failed
+      .map((failure) =>
+        failure.id === undefined
+          ? `  ${failure.module}: ${failure.error.message}`
+          : `  ${failure.module} rev ${failure.id} "${failure.name}": ${failure.error.message}`,
+      )
+      .join("\n");
+    super(`${report.failed.length} migration module(s) failed\n${summary}`, "MigrationFailedError");
+    this.report = report;
+  }
+}

--- a/migrations/src/extension.test.ts
+++ b/migrations/src/extension.test.ts
@@ -1,0 +1,224 @@
+import { Provider } from "@algorandfoundation/wallet-provider";
+import type { Extension } from "@algorandfoundation/wallet-provider";
+import { describe, expect, it, vi } from "vitest";
+import { MigrationFailedError, MissingLedgerError } from "./errors.ts";
+import { WithMigrations } from "./extension.ts";
+import { memoryLedger } from "./ledger.ts";
+import type { MigrationReport, MigrationsApi } from "./types.ts";
+
+/** Builds an extension that registers `ids` as revisions for `module`. */
+function registering(module: string, ids: number[], order: string[]): Extension<object> {
+  return (provider: any) => {
+    provider.migrations?.register({
+      module,
+      context: () => ({}),
+      migrations: ids.map((id) => ({
+        id,
+        name: `rev-${id}`,
+        up: () => {
+          order.push(`${module}:${id}`);
+        },
+      })),
+    });
+    return {};
+  };
+}
+
+describe("WithMigrations", () => {
+  it("throws MissingLedgerError when no ledger is configured", () => {
+    const P = Provider.withExtensions([WithMigrations]);
+    expect(() => new P({ id: "p", name: "P" }, {})).toThrow(MissingLedgerError);
+  });
+
+  it("exposes the registry to later extensions", () => {
+    const order: string[] = [];
+    const P = Provider.withExtensions([WithMigrations, registering("a", [1], order)]);
+    const provider = new P(
+      { id: "p", name: "P" },
+      { migrations: { ledger: memoryLedger() } },
+    ) as any;
+
+    expect(provider.migrations).toBeDefined();
+    expect(typeof provider.migrations.register).toBe("function");
+  });
+
+  it("runs every registered module after the constructor completes", async () => {
+    const order: string[] = [];
+    const P = Provider.withExtensions([
+      WithMigrations,
+      registering("a", [1, 2], order),
+      registering("b", [1], order),
+    ]);
+    const provider = new P(
+      { id: "p", name: "P" },
+      { migrations: { ledger: memoryLedger() } },
+    ) as any;
+
+    // Nothing has run yet: the microtask cannot fire until the synchronous
+    // constructor loop is done.
+    expect(order).toEqual([]);
+
+    const report: MigrationReport = await provider.migrations.ready;
+
+    expect(order).toEqual(["a:1", "a:2", "b:1"]);
+    expect(report.applied).toHaveLength(3);
+  });
+
+  it("persists revisions to the supplied ledger", async () => {
+    const ledger = memoryLedger();
+    const order: string[] = [];
+    const P = Provider.withExtensions([WithMigrations, registering("a", [1, 2], order)]);
+    const provider = new P({ id: "p", name: "P" }, { migrations: { ledger } }) as any;
+
+    await provider.migrations.ready;
+
+    expect((await ledger.read())["a"]?.id).toBe(2);
+  });
+
+  it("does not run until run() is called when autoRun is false", async () => {
+    const order: string[] = [];
+    const P = Provider.withExtensions([WithMigrations, registering("a", [1], order)]);
+    const provider = new P(
+      { id: "p", name: "P" },
+      { migrations: { ledger: memoryLedger(), autoRun: false } },
+    ) as any;
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(order).toEqual([]);
+
+    await provider.migrations.run();
+    expect(order).toEqual(["a:1"]);
+  });
+
+  it("returns the same promise from run() and ready, and runs only once", async () => {
+    const order: string[] = [];
+    const P = Provider.withExtensions([WithMigrations, registering("a", [1], order)]);
+    const provider = new P(
+      { id: "p", name: "P" },
+      { migrations: { ledger: memoryLedger(), autoRun: false } },
+    ) as any;
+
+    const api = provider.migrations as MigrationsApi;
+    const first = api.run();
+    const second = api.run();
+
+    expect(first).toBe(second);
+    expect(first).toBe(api.ready);
+    await first;
+    expect(order).toEqual(["a:1"]);
+  });
+
+  it("rejects `ready` with MigrationFailedError when a revision throws", async () => {
+    const P = Provider.withExtensions([
+      WithMigrations,
+      (provider: any) => {
+        provider.migrations?.register({
+          module: "a",
+          context: () => ({}),
+          migrations: [
+            {
+              id: 1,
+              name: "boom",
+              up: () => {
+                throw new Error("boom");
+              },
+            },
+          ],
+        });
+        return {};
+      },
+    ]);
+    const provider = new P(
+      { id: "p", name: "P" },
+      { migrations: { ledger: memoryLedger() } },
+    ) as any;
+
+    await expect(provider.migrations.ready).rejects.toBeInstanceOf(MigrationFailedError);
+  });
+
+  it("does not raise an unhandled rejection when `ready` is never awaited", async () => {
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+
+    const P = Provider.withExtensions([
+      WithMigrations,
+      (provider: any) => {
+        provider.migrations?.register({
+          module: "a",
+          context: () => ({}),
+          migrations: [
+            {
+              id: 1,
+              name: "boom",
+              up: () => {
+                throw new Error("boom");
+              },
+            },
+          ],
+        });
+        return {};
+      },
+    ]);
+    new P({ id: "p", name: "P" }, { migrations: { ledger: memoryLedger() } });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    process.off("unhandledRejection", unhandled);
+
+    expect(unhandled).not.toHaveBeenCalled();
+  });
+
+  it("uses a log extension applied AFTER it", async () => {
+    const info = vi.fn();
+    const order: string[] = [];
+    const withLog: Extension<{ log: unknown }> = () => ({
+      log: { info, warn: vi.fn(), error: vi.fn() },
+    });
+    const P = Provider.withExtensions([WithMigrations, withLog, registering("a", [1], order)]);
+    const provider = new P(
+      { id: "p", name: "P" },
+      { migrations: { ledger: memoryLedger() } },
+    ) as any;
+
+    await provider.migrations.ready;
+
+    expect(info).toHaveBeenCalled();
+  });
+
+  it("tolerates a provider with no log extension", async () => {
+    const order: string[] = [];
+    const P = Provider.withExtensions([WithMigrations, registering("a", [1], order)]);
+    const provider = new P(
+      { id: "p", name: "P" },
+      { migrations: { ledger: memoryLedger() } },
+    ) as any;
+
+    await expect(provider.migrations.ready).resolves.toBeDefined();
+  });
+
+  it("exposes a hook collection that fires per revision", async () => {
+    const order: string[] = [];
+    const seen: unknown[] = [];
+    const P = Provider.withExtensions([WithMigrations, registering("a", [1], order)]);
+    const provider = new P(
+      { id: "p", name: "P" },
+      { migrations: { ledger: memoryLedger() } },
+    ) as any;
+
+    provider.migrations.hooks.before("migrate", (options: unknown) => {
+      seen.push(options);
+    });
+
+    await provider.migrations.ready;
+    expect(seen).toHaveLength(1);
+  });
+
+  it("makes register a no-op when WithMigrations is absent", () => {
+    const order: string[] = [];
+    const P = Provider.withExtensions([registering("a", [1], order)]);
+    const provider = new P({ id: "p", name: "P" }, {}) as any;
+
+    expect(provider.migrations).toBeUndefined();
+    expect(order).toEqual([]);
+  });
+});

--- a/migrations/src/extension.ts
+++ b/migrations/src/extension.ts
@@ -1,0 +1,104 @@
+import type { Extension } from "@algorandfoundation/wallet-provider";
+import Hook from "before-after-hook";
+import { applyMigrations } from "./apply.ts";
+import { MissingLedgerError } from "./errors.ts";
+import type {
+  MigrationLogger,
+  MigrationModule,
+  MigrationReport,
+  MigrationsApi,
+  MigrationsExtension,
+  MigrationsOptions,
+} from "./types.ts";
+
+/**
+ * Provider extension that discovers and applies pending data migrations.
+ *
+ * Place it **first** in the extensions array. It contributes
+ * `provider.migrations`, which every later extension can register with using the
+ * optional-dependency probe (`provider.migrations?.register(...)`). Because the
+ * `Provider` constructor applies extensions synchronously and the run is
+ * scheduled on a microtask, the registry is always complete before the first
+ * revision executes.
+ *
+ * When this extension is absent, `provider.migrations` is `undefined` and every
+ * `register` call is a no-op — that is the opt-in mechanism.
+ *
+ * @param provider - The provider being extended.
+ * @param options - {@link MigrationsOptions}. `migrations.ledger` is required.
+ * @returns The `migrations` API.
+ * @throws {MissingLedgerError} When no ledger is configured.
+ *
+ * @example
+ * ```typescript
+ * const MyProvider = Provider.withExtensions([WithMigrations, WithKeyStore]);
+ * const provider = new MyProvider(
+ *   { id: "wallet", name: "Wallet" },
+ *   { migrations: { ledger: keyValueLedger(kv) }, keystore: { store, hooks } },
+ * );
+ * await provider.migrations.ready;
+ * ```
+ */
+export const WithMigrations: Extension<MigrationsExtension> = (
+  provider: any,
+  options: MigrationsOptions,
+): MigrationsExtension => {
+  const ledger = options?.migrations?.ledger;
+  if (!ledger) {
+    throw new MissingLedgerError();
+  }
+
+  const hooks = options.migrations.hooks ?? new Hook.Collection<any>();
+  const autoRun = options.migrations.autoRun ?? true;
+  const registry: MigrationModule<any>[] = [];
+
+  let resolveReady!: (report: MigrationReport) => void;
+  let rejectReady!: (error: unknown) => void;
+  const ready = new Promise<MigrationReport>((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
+  // An application is free never to await `ready`. Without this the rejection
+  // would surface as an unhandled promise rejection; callers still see it.
+  ready.catch(() => {
+    /* surfaced through `ready` / `run()` to whoever awaits them */
+  });
+
+  let started = false;
+  const run = (): Promise<MigrationReport> => {
+    if (!started) {
+      started = true;
+      applyMigrations({
+        registry,
+        ledger,
+        hooks,
+        // Resolved here, not at construction time: this extension runs first,
+        // so a log extension applied after it does not exist yet above.
+        log: provider?.log as MigrationLogger | undefined,
+      }).then(resolveReady, rejectReady);
+    }
+    return ready;
+  };
+
+  if (autoRun) {
+    // A microtask cannot run until the synchronous `EXTENSIONS.forEach` loop in
+    // the Provider constructor has finished, so every module is registered by
+    // the time the first revision executes.
+    void Promise.resolve().then(() => {
+      void run();
+    });
+  }
+
+  const api: MigrationsApi = {
+    register<Ctx>(module: MigrationModule<Ctx>): void {
+      registry.push(module as MigrationModule<any>);
+    },
+    get ready(): Promise<MigrationReport> {
+      return ready;
+    },
+    run,
+    hooks,
+  };
+
+  return { migrations: api };
+};

--- a/migrations/src/index.ts
+++ b/migrations/src/index.ts
@@ -1,0 +1,10 @@
+import { WithMigrations } from "./extension.ts";
+
+export * from "./apply.ts";
+export * from "./errors.ts";
+export * from "./extension.ts";
+export * from "./ledger.ts";
+export * from "./secrets.ts";
+export * from "./types.ts";
+
+export default WithMigrations;

--- a/migrations/src/ledger.test.ts
+++ b/migrations/src/ledger.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_LEDGER_KEY, keyValueLedger, memoryLedger } from "./ledger.ts";
+import type { KeyValueStore, Revision } from "./types.ts";
+
+const revision: Revision = { id: 2, name: "second", appliedAt: "2026-01-01T00:00:00.000Z" };
+
+/** A synchronous in-memory {@link KeyValueStore}, like MMKV or localStorage. */
+function syncStore(
+  seed: Record<string, string> = {},
+): KeyValueStore & { raw: Map<string, string> } {
+  const raw = new Map<string, string>(Object.entries(seed));
+  return {
+    raw,
+    get: (key) => raw.get(key),
+    set: (key, value) => {
+      raw.set(key, value);
+    },
+  };
+}
+
+/** An asynchronous {@link KeyValueStore}, like AsyncStorage. */
+function asyncStore(): KeyValueStore & { raw: Map<string, string> } {
+  const raw = new Map<string, string>();
+  return {
+    raw,
+    get: (key) => Promise.resolve(raw.get(key) ?? null),
+    set: async (key, value) => {
+      raw.set(key, value);
+    },
+  };
+}
+
+describe("memoryLedger", () => {
+  it("starts empty", async () => {
+    expect(await memoryLedger().read()).toEqual({});
+  });
+
+  it("reads back what was written", async () => {
+    const ledger = memoryLedger();
+    await ledger.write("@scope/pkg", revision);
+    expect(await ledger.read()).toEqual({ "@scope/pkg": revision });
+  });
+
+  it("seeds from an initial map", async () => {
+    const ledger = memoryLedger({ "@scope/pkg": revision });
+    expect(await ledger.read()).toEqual({ "@scope/pkg": revision });
+  });
+
+  it("returns a snapshot that later writes do not mutate", async () => {
+    const ledger = memoryLedger();
+    const before = await ledger.read();
+    await ledger.write("@scope/pkg", revision);
+    expect(before).toEqual({});
+  });
+});
+
+describe("keyValueLedger", () => {
+  it("reads an absent key as an empty map", async () => {
+    expect(await keyValueLedger(syncStore()).read()).toEqual({});
+  });
+
+  it("round-trips through a synchronous store", async () => {
+    const kv = syncStore();
+    const ledger = keyValueLedger(kv);
+
+    await ledger.write("@scope/pkg", revision);
+
+    expect(await ledger.read()).toEqual({ "@scope/pkg": revision });
+    expect(kv.raw.has(DEFAULT_LEDGER_KEY)).toBe(true);
+  });
+
+  it("round-trips through an asynchronous store", async () => {
+    const ledger = keyValueLedger(asyncStore());
+    await ledger.write("@scope/pkg", revision);
+    expect(await ledger.read()).toEqual({ "@scope/pkg": revision });
+  });
+
+  it("preserves other modules when writing one", async () => {
+    const ledger = keyValueLedger(syncStore());
+    await ledger.write("@scope/a", revision);
+    await ledger.write("@scope/b", { id: 1, name: "first", appliedAt: "2026-01-02T00:00:00.000Z" });
+
+    const state = await ledger.read();
+    expect(Object.keys(state).sort()).toEqual(["@scope/a", "@scope/b"]);
+    expect(state["@scope/a"]).toEqual(revision);
+  });
+
+  it("honours a custom storage key", async () => {
+    const kv = syncStore();
+    await keyValueLedger(kv, { key: "custom" }).write("@scope/pkg", revision);
+    expect(kv.raw.has("custom")).toBe(true);
+    expect(kv.raw.has(DEFAULT_LEDGER_KEY)).toBe(false);
+  });
+
+  it("reads corrupt JSON as empty rather than throwing", async () => {
+    const kv = syncStore({ [DEFAULT_LEDGER_KEY]: "{not json" });
+    expect(await keyValueLedger(kv).read()).toEqual({});
+  });
+
+  it("reads a non-object payload as empty", async () => {
+    const kv = syncStore({ [DEFAULT_LEDGER_KEY]: "[1,2,3]" });
+    expect(await keyValueLedger(kv).read()).toEqual({});
+  });
+});

--- a/migrations/src/ledger.ts
+++ b/migrations/src/ledger.ts
@@ -1,0 +1,92 @@
+import type { KeyValueStore, MigrationLedger, Revision } from "./types.ts";
+
+/** Default storage key under which the whole ledger map is serialised. */
+export const DEFAULT_LEDGER_KEY: string = "@algorandfoundation/provider-migrations";
+
+/**
+ * An in-memory {@link MigrationLedger}.
+ *
+ * Nothing survives a restart, so every migration re-runs on the next launch.
+ * Intended for tests and deliberately ephemeral use — never as an application's
+ * durable ledger.
+ *
+ * @param initial - Revisions to seed the ledger with.
+ * @returns An in-memory {@link MigrationLedger}.
+ *
+ * @example
+ * ```typescript
+ * const ledger = memoryLedger({ "@scope/pkg": { id: 1, name: "first", appliedAt: iso } });
+ * ```
+ */
+export function memoryLedger(initial: Record<string, Revision> = {}): MigrationLedger {
+  const state: Record<string, Revision> = { ...initial };
+  return {
+    read(): Promise<Record<string, Revision>> {
+      return Promise.resolve({ ...state });
+    },
+    write(module: string, revision: Revision): Promise<void> {
+      state[module] = revision;
+      return Promise.resolve();
+    },
+  };
+}
+
+/**
+ * A {@link MigrationLedger} backed by any string key/value store.
+ *
+ * The whole map is serialised as one JSON blob under a single key, so a run
+ * resolves the entire graph with one read. An absent, unparseable, or
+ * non-object payload reads as empty — which re-runs every migration, and is
+ * safe precisely because migrations are required to be idempotent.
+ *
+ * @param kv - The backing store. MMKV, `localStorage`, AsyncStorage, or a file
+ *   wrapper all adapt in two lines.
+ * @param options - Optional storage key override.
+ * @returns A durable {@link MigrationLedger}.
+ *
+ * @example
+ * ```typescript
+ * keyValueLedger({ get: (k) => mmkv.getString(k), set: (k, v) => mmkv.set(k, v) });
+ * ```
+ */
+export function keyValueLedger(kv: KeyValueStore, options?: { key?: string }): MigrationLedger {
+  const key = options?.key ?? DEFAULT_LEDGER_KEY;
+
+  async function load(): Promise<Record<string, Revision>> {
+    const raw = await kv.get(key);
+    if (!raw) {
+      return {};
+    }
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return {};
+      }
+      return parsed as Record<string, Revision>;
+    } catch {
+      // A corrupt ledger is treated as absent: every migration re-runs, which
+      // idempotency makes safe. Throwing here would brick the application.
+      return {};
+    }
+  }
+
+  return {
+    read(): Promise<Record<string, Revision>> {
+      return load();
+    },
+    /**
+     * Read-modify-write over the single JSON blob: `load()` the whole map,
+     * patch this module's entry, then write the whole map back. Safe within a
+     * single sequential run (revisions are applied one at a time and this
+     * ledger is only ever awaited, never fired concurrently, by
+     * `applyMigrations`), but if two provider instances shared one ledger and
+     * called `write` concurrently, the later write's `load()` could miss the
+     * earlier one's not-yet-persisted change and clobber it on save.
+     */
+    async write(module: string, revision: Revision): Promise<void> {
+      const state = await load();
+      state[module] = revision;
+      await kv.set(key, JSON.stringify(state));
+    },
+  };
+}

--- a/migrations/src/secrets.test.ts
+++ b/migrations/src/secrets.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { SecretNotFoundError, SecretScratchDisposedError } from "./errors.ts";
+import { createSecretScratch } from "./secrets.ts";
+
+describe("createSecretScratch", () => {
+  it("lends stored bytes to `use` without copying them", async () => {
+    const { scratch } = createSecretScratch();
+    const bytes = new Uint8Array([1, 2, 3]);
+    scratch.put("seed", bytes);
+
+    const seen = await scratch.use("seed", (value) => value);
+
+    expect(seen).toBe(bytes);
+    expect(scratch.has("seed")).toBe(true);
+  });
+
+  it("supports an async consumer in `use`", async () => {
+    const { scratch } = createSecretScratch();
+    scratch.put("seed", new Uint8Array([9]));
+
+    const result = await scratch.use("seed", async (value) => value.length);
+
+    expect(result).toBe(1);
+  });
+
+  it("keeps the entry live after `use` returns", async () => {
+    const { scratch } = createSecretScratch();
+    scratch.put("seed", new Uint8Array([1]));
+
+    await scratch.use("seed", () => undefined);
+
+    expect(scratch.has("seed")).toBe(true);
+  });
+
+  it("zeroes the caller's buffer on wipe", () => {
+    const { scratch } = createSecretScratch();
+    const bytes = new Uint8Array([1, 2, 3]);
+    scratch.put("seed", bytes);
+
+    scratch.wipe("seed");
+
+    expect(Array.from(bytes)).toEqual([0, 0, 0]);
+    expect(scratch.has("seed")).toBe(false);
+  });
+
+  it("zeroes a replaced buffer when the same label is put twice", () => {
+    const { scratch } = createSecretScratch();
+    const first = new Uint8Array([1, 2, 3]);
+    const second = new Uint8Array([4, 5, 6]);
+    scratch.put("seed", first);
+
+    scratch.put("seed", second);
+
+    expect(Array.from(first)).toEqual([0, 0, 0]);
+    expect(Array.from(second)).toEqual([4, 5, 6]);
+  });
+
+  it("treats wiping an unknown label as a no-op", () => {
+    const { scratch } = createSecretScratch();
+    expect(() => scratch.wipe("nothing")).not.toThrow();
+  });
+
+  it("throws SecretNotFoundError when using an unknown label", async () => {
+    const { scratch } = createSecretScratch();
+    await expect(scratch.use("nothing", (v) => v)).rejects.toBeInstanceOf(SecretNotFoundError);
+  });
+
+  it("zeroes every buffer on wipeAll", () => {
+    const { scratch, wipeAll } = createSecretScratch();
+    const a = new Uint8Array([1, 2]);
+    const b = new Uint8Array([3, 4]);
+    scratch.put("a", a);
+    scratch.put("b", b);
+
+    wipeAll();
+
+    expect(Array.from(a)).toEqual([0, 0]);
+    expect(Array.from(b)).toEqual([0, 0]);
+  });
+
+  it("throws SecretScratchDisposedError on any use after wipeAll", async () => {
+    const { scratch, wipeAll } = createSecretScratch();
+    scratch.put("seed", new Uint8Array([1]));
+    wipeAll();
+
+    await expect(scratch.use("seed", (v) => v)).rejects.toBeInstanceOf(SecretScratchDisposedError);
+    expect(() => scratch.put("seed", new Uint8Array([1]))).toThrow(SecretScratchDisposedError);
+    expect(() => scratch.has("seed")).toThrow(SecretScratchDisposedError);
+    expect(() => scratch.wipe("seed")).toThrow(SecretScratchDisposedError);
+  });
+
+  it("is idempotent on repeated wipeAll", () => {
+    const { wipeAll } = createSecretScratch();
+    wipeAll();
+    expect(() => wipeAll()).not.toThrow();
+  });
+
+  it("redacts material from JSON.stringify", () => {
+    const { scratch } = createSecretScratch();
+    scratch.put("seed", new Uint8Array([222, 173, 190, 239]));
+
+    expect(JSON.stringify({ secrets: scratch })).toBe('{"secrets":"[SecretScratch]"}');
+  });
+});

--- a/migrations/src/secrets.ts
+++ b/migrations/src/secrets.ts
@@ -1,0 +1,104 @@
+import { SecretNotFoundError, SecretScratchDisposedError } from "./errors.ts";
+import type { SecretScratch } from "./types.ts";
+
+/**
+ * A {@link SecretScratch} paired with the wipe control the runner retains.
+ *
+ * The migration only ever receives `scratch`, so it cannot extend the lifetime
+ * of the material it holds.
+ */
+export interface SecretScratchHandle {
+  /** Handed to the migration as `utils.secrets`. */
+  scratch: SecretScratch;
+  /** Zeroes every entry and disposes the scratch. Idempotent. */
+  wipeAll(): void;
+}
+
+/**
+ * Creates a run-scoped, in-memory scratch for secret material.
+ *
+ * Material is held as raw `Uint8Array` — never strings, which are immutable,
+ * cannot be zeroed, and leak into logs. Nothing is ever written to durable
+ * storage. The runner creates one scratch per revision and wipes it in a
+ * `finally`, so buffers are zeroed whether the revision succeeds or throws.
+ *
+ * @returns A {@link SecretScratchHandle}.
+ *
+ * @example
+ * ```typescript
+ * const { scratch, wipeAll } = createSecretScratch();
+ * try {
+ *   scratch.put("seed", await oldStore.read(id));
+ *   await scratch.use("seed", (bytes) => newStore.write(id, bytes));
+ * } finally {
+ *   wipeAll();
+ * }
+ * ```
+ */
+export function createSecretScratch(): SecretScratchHandle {
+  const entries = new Map<string, Uint8Array>();
+  let disposed = false;
+
+  function assertLive(): void {
+    if (disposed) {
+      throw new SecretScratchDisposedError();
+    }
+  }
+
+  function read(label: string): Uint8Array {
+    assertLive();
+    const bytes = entries.get(label);
+    if (bytes === undefined) {
+      throw new SecretNotFoundError(label);
+    }
+    return bytes;
+  }
+
+  const scratch: SecretScratch = {
+    put(label: string, bytes: Uint8Array): void {
+      assertLive();
+      const previous = entries.get(label);
+      if (previous !== undefined) {
+        previous.fill(0);
+      }
+      entries.set(label, bytes);
+    },
+    async use<T>(label: string, fn: (bytes: Uint8Array) => T | Promise<T>): Promise<T> {
+      return fn(read(label));
+    },
+    has(label: string): boolean {
+      assertLive();
+      return entries.has(label);
+    },
+    wipe(label: string): void {
+      assertLive();
+      const bytes = entries.get(label);
+      if (bytes === undefined) {
+        return;
+      }
+      bytes.fill(0);
+      entries.delete(label);
+    },
+    toJSON(): string {
+      return "[SecretScratch]";
+    },
+  };
+
+  // Node's inspector bypasses `toJSON`, so redact that path too. Non-enumerable
+  // so it never shows up in a spread or `Object.keys`.
+  Object.defineProperty(scratch, Symbol.for("nodejs.util.inspect.custom"), {
+    value: (): string => "[SecretScratch]",
+    enumerable: false,
+  });
+
+  return {
+    scratch,
+    wipeAll(): void {
+      for (const bytes of entries.values()) {
+        bytes.fill(0);
+      }
+      entries.clear();
+      disposed = true;
+    },
+  };
+}

--- a/migrations/src/testing.test.ts
+++ b/migrations/src/testing.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "vitest";
+import { assertIdempotent } from "./testing.ts";
+import type { Migration } from "./types.ts";
+
+/** A trivial record store standing in for a real storage context. */
+type Store = { records: Record<string, number> };
+
+describe("assertIdempotent", () => {
+  it("passes for a migration that converges", async () => {
+    const migration: Migration<Store> = {
+      id: 1,
+      name: "set-flag",
+      up: (store) => {
+        for (const key of Object.keys(store.records)) {
+          store.records[key] = 1;
+        }
+      },
+    };
+
+    await expect(
+      assertIdempotent({
+        migration,
+        context: () => ({ records: { a: 0, b: 0 } }),
+        snapshot: (store) => store.records,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("passes for a migration that is a no-op on empty data", async () => {
+    const migration: Migration<Store> = { id: 1, name: "noop", up: () => undefined };
+
+    await expect(
+      assertIdempotent({
+        migration,
+        context: () => ({ records: {} }),
+        snapshot: (store) => store.records,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws for a migration that accumulates on every run", async () => {
+    const migration: Migration<Store> = {
+      id: 1,
+      name: "increment",
+      up: (store) => {
+        for (const key of Object.keys(store.records)) {
+          store.records[key] = (store.records[key] ?? 0) + 1;
+        }
+      },
+    };
+
+    await expect(
+      assertIdempotent({
+        migration,
+        context: () => ({ records: { a: 0 } }),
+        snapshot: (store) => store.records,
+      }),
+    ).rejects.toThrow(/not idempotent/);
+  });
+
+  it("names the migration in the failure message", async () => {
+    const migration: Migration<Store> = {
+      id: 3,
+      name: "double",
+      up: (store) => {
+        store.records["a"] = (store.records["a"] ?? 1) * 2;
+      },
+    };
+
+    await expect(
+      assertIdempotent({
+        migration,
+        context: () => ({ records: { a: 1 } }),
+        snapshot: (store) => store.records,
+      }),
+    ).rejects.toThrow(/"double".*3|3.*"double"/s);
+  });
+
+  it("ignores object key ordering", async () => {
+    const migration: Migration<{ value: Record<string, number> }> = {
+      id: 1,
+      name: "reorder",
+      up: (ctx) => {
+        // Rewrites the same data with the keys inserted in the opposite order.
+        ctx.value = Object.fromEntries(Object.entries(ctx.value).reverse());
+      },
+    };
+
+    await expect(
+      assertIdempotent({
+        migration,
+        context: () => ({ value: { a: 1, b: 2 } }),
+        snapshot: (ctx) => ctx.value,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("renders Uint8Array snapshots via Array.from, not the generic object branch", async () => {
+    // Non-idempotent by construction: every run shifts every byte up by one,
+    // so the two runs are guaranteed to differ and `assertIdempotent` throws —
+    // which lets us inspect exactly how it rendered the two snapshots.
+    //
+    // This is deliberately not just "does assertIdempotent report a
+    // difference" — plain equality of two Uint8Arrays with different content
+    // is detected identically whether or not `normalise` special-cases
+    // `Uint8Array` (both a JSON array and a JSON object rendering of the same
+    // byte sequence differ from each other as strings). What only the
+    // `instanceof Uint8Array` branch guarantees is the *rendering itself*:
+    // `Array.from` first (`[6,\n  7]`), never the generic keyed-object
+    // fallback (`{"0":6,"1":7}`) that a `Uint8Array` would otherwise hit
+    // (typed arrays are plain objects with own enumerable index keys).
+    const migration: Migration<{ bytes: Uint8Array }> = {
+      id: 1,
+      name: "increment",
+      up: (ctx) => {
+        ctx.bytes = ctx.bytes.map((b) => b + 1);
+      },
+    };
+
+    let error: Error | undefined;
+    try {
+      await assertIdempotent({
+        migration,
+        context: () => ({ bytes: new Uint8Array([5, 6]) }),
+        snapshot: (ctx) => ctx.bytes,
+      });
+    } catch (caught) {
+      error = caught as Error;
+    }
+
+    expect(error).toBeDefined();
+    expect(error!.message).toContain("[\n  6,\n  7\n]");
+    expect(error!.message).not.toContain('"0":');
+  });
+
+  it("supports an async snapshot and an async up", async () => {
+    const migration: Migration<Store> = {
+      id: 1,
+      name: "async-noop",
+      up: async () => undefined,
+    };
+
+    await expect(
+      assertIdempotent({
+        migration,
+        context: async () => ({ records: {} }),
+        snapshot: async (store) => store.records,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("supplies a working scratch to each run", async () => {
+    const migration: Migration<Store> = {
+      id: 1,
+      name: "uses-scratch",
+      up: async (_store, utils) => {
+        utils.secrets.put("seed", new Uint8Array([1]));
+        await utils.secrets.use("seed", (bytes) => bytes.length);
+      },
+    };
+
+    await expect(
+      assertIdempotent({
+        migration,
+        context: () => ({ records: {} }),
+        snapshot: (store) => store.records,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws a clear error when `snapshot` returns undefined", async () => {
+    // A snapshot callback that forgets its `return` (e.g. `(s) => { dump(s); }`)
+    // yields `undefined`; `JSON.stringify(undefined) === undefined` on every
+    // run, so without this check the comparison would pass vacuously no
+    // matter what the migration does.
+    const migration: Migration<Store> = {
+      id: 1,
+      name: "doubles-every-record",
+      up: (store) => {
+        for (const key of Object.keys(store.records)) {
+          store.records[key] = (store.records[key] ?? 0) * 2;
+        }
+      },
+    };
+
+    await expect(
+      assertIdempotent({
+        migration,
+        context: () => ({ records: { a: 1 } }),
+        snapshot: () => {
+          // Deliberately missing `return` — the bug under test.
+        },
+      }),
+    ).rejects.toThrow(/snapshot.*undefined|undefined.*return/is);
+  });
+
+  it("throws a clear error, naming Map, when the snapshot contains a Map", async () => {
+    await expect(
+      assertIdempotent({
+        migration: { id: 1, name: "noop", up: () => undefined },
+        context: () => ({ map: new Map([["a", 1]]) }),
+        snapshot: (ctx) => ctx.map,
+      }),
+    ).rejects.toThrow(/\bMap\b/);
+  });
+
+  it("throws a clear error, naming Set, when the snapshot contains a Set", async () => {
+    await expect(
+      assertIdempotent({
+        migration: { id: 1, name: "noop", up: () => undefined },
+        context: () => ({ set: new Set([1, 2]) }),
+        snapshot: (ctx) => ctx.set,
+      }),
+    ).rejects.toThrow(/\bSet\b/);
+  });
+
+  it("reports a doubling migration as non-idempotent even though its snapshot is a Map", async () => {
+    // Before the fix: `normalise` fell into the plain-object branch for a
+    // `Map`, whose `Object.keys()` sees none of its entries, so both runs
+    // stringified to "{}" and this doubling migration passed vacuously.
+    const migration: Migration<{ map: Map<string, number> }> = {
+      id: 1,
+      name: "double",
+      up: (ctx) => {
+        for (const [key, value] of ctx.map) {
+          ctx.map.set(key, value * 2);
+        }
+      },
+    };
+
+    await expect(
+      assertIdempotent({
+        migration,
+        context: () => ({ map: new Map([["a", 1]]) }),
+        snapshot: (ctx) => ctx.map,
+      }),
+    ).rejects.toThrow(); // no longer resolves — the Map is rejected outright, not silently treated as `{}`
+  });
+});

--- a/migrations/src/testing.ts
+++ b/migrations/src/testing.ts
@@ -1,0 +1,124 @@
+import { createSecretScratch } from "./secrets.ts";
+import type { Migration, MigrationUtils } from "./types.ts";
+
+/** Arguments for {@link assertIdempotent}. */
+export interface AssertIdempotentOptions<Ctx> {
+  /** The revision under test. */
+  migration: Migration<Ctx>;
+  /** Builds the context. Called once — both runs share it, as in production. */
+  context: () => Ctx | Promise<Ctx>;
+  /** Captures the observable state after a run, for comparison. */
+  snapshot: (context: Ctx) => unknown | Promise<unknown>;
+  /** Module id used in `utils.revision`. Defaults to `"assertIdempotent"`. */
+  module?: string;
+}
+
+/**
+ * Asserts that a migration converges: running it twice against the same context
+ * must leave identical state.
+ *
+ * Every revision must satisfy this. The runner records the ledger after each
+ * revision, so a re-run only happens when something else went wrong — a failed
+ * ledger write, storage cleared underneath the application, a partially applied
+ * revision resumed. Those are exactly the cases where a non-idempotent
+ * migration corrupts data.
+ *
+ * Snapshots are compared structurally: object key order is normalised and
+ * `Uint8Array` values are compared by content, so a rewrite that only changes
+ * insertion order does not read as a difference.
+ *
+ * @param options - {@link AssertIdempotentOptions}.
+ * @throws {Error} When the two runs produce different snapshots.
+ * @throws {Error} When `snapshot` returns `undefined` (almost always a missing
+ *   `return`) — an undefined snapshot always compares equal to itself, which
+ *   would otherwise let a non-idempotent migration pass unnoticed.
+ * @throws {Error} When the snapshot contains a `Map` or `Set` — neither
+ *   survives structural comparison (both normalise to `{}` regardless of
+ *   content); convert to an array or plain object first.
+ *
+ * @example
+ * ```typescript
+ * await assertIdempotent({
+ *   migration,
+ *   context: () => seededStorage(),
+ *   snapshot: (storage) => storage.entries(),
+ * });
+ * ```
+ */
+export async function assertIdempotent<Ctx>(options: AssertIdempotentOptions<Ctx>): Promise<void> {
+  const { migration, snapshot } = options;
+  const module = options.module ?? "assertIdempotent";
+  const context = await options.context();
+
+  async function runOnce(): Promise<string> {
+    const { scratch, wipeAll } = createSecretScratch();
+    const utils: MigrationUtils = {
+      revision: { module, id: migration.id, name: migration.name },
+      secrets: scratch,
+    };
+    try {
+      await migration.up(context, utils);
+    } finally {
+      wipeAll();
+    }
+    const captured = await snapshot(context);
+    if (captured === undefined) {
+      throw new Error(
+        `assertIdempotent: \`snapshot\` returned undefined for migration "${migration.name}" ` +
+          `(revision ${migration.id}). Did the callback forget its \`return\` statement? ` +
+          "`JSON.stringify(undefined)` is also `undefined`, so an undefined snapshot would " +
+          "compare equal on every run and let a non-idempotent migration pass unnoticed — " +
+          "return the observable state instead (e.g. `(storage) => storage.entries()`).",
+      );
+    }
+    return JSON.stringify(normalise(captured), null, 2);
+  }
+
+  const first = await runOnce();
+  const second = await runOnce();
+
+  if (first !== second) {
+    throw new Error(
+      `Migration "${migration.name}" (revision ${migration.id}) is not idempotent.\n` +
+        `After the first run:\n${first}\n\nAfter the second run:\n${second}`,
+    );
+  }
+}
+
+/**
+ * Recursively normalises a snapshot so comparison is order-insensitive:
+ * object keys are sorted and typed arrays become plain number arrays.
+ *
+ * `Map` and `Set` are rejected outright rather than silently normalised: both
+ * would fall through to the plain-object branch, whose `Object.keys()` sees
+ * none of their entries, so every `Map`/`Set` — regardless of content —
+ * collapses to the same `{}` and a migration that corrupts one on every run
+ * would pass `assertIdempotent` vacuously.
+ */
+function normalise(value: unknown): unknown {
+  if (value instanceof Uint8Array) {
+    return Array.from(value);
+  }
+  if (value instanceof Map || value instanceof Set) {
+    const kind = value instanceof Map ? "Map" : "Set";
+    throw new Error(
+      `assertIdempotent: snapshot contains a ${kind}, which \`JSON.stringify\` cannot see the ` +
+        `contents of (it normalises to "{}" regardless of what it holds), so a non-idempotent ` +
+        `migration could pass unnoticed. Convert it in your \`snapshot\` callback — e.g. ` +
+        `\`Array.from(value.entries())\` for a Map, or \`Array.from(value)\` for a Set — or to a ` +
+        "plain object.",
+    );
+  }
+  if (Array.isArray(value)) {
+    return value.map(normalise);
+  }
+  if (value !== null && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.keys(record)
+        .sort()
+        .map((key) => [key, normalise(record[key])]),
+    );
+  }
+  return value;
+}

--- a/migrations/src/types.ts
+++ b/migrations/src/types.ts
@@ -1,0 +1,183 @@
+import type { ExtensionOptions } from "@algorandfoundation/wallet-provider";
+import type { HookCollection } from "before-after-hook";
+
+/**
+ * A revision recorded in the ledger: the last migration a module successfully
+ * applied.
+ */
+export interface Revision {
+  /** The revision id that was applied. */
+  id: number;
+  /** The revision's human-readable name. */
+  name: string;
+  /** ISO-8601 timestamp of when it was applied. */
+  appliedAt: string;
+}
+
+/**
+ * Run-scoped, in-memory custodian for secret material moving between storages.
+ *
+ * Created fresh for each revision and wiped by the runner once the revision
+ * settles, so material never outlives the migration that handled it.
+ */
+export interface SecretScratch {
+  /**
+   * Takes ownership of `bytes`. The caller must not touch the array afterwards.
+   * Deliberately does not copy — a copy would mean a second plaintext buffer
+   * alive in the heap.
+   */
+  put(label: string, bytes: Uint8Array): void;
+  /** Lends the stored bytes to `fn` for the duration of the call only. */
+  use<T>(label: string, fn: (bytes: Uint8Array) => T | Promise<T>): Promise<T>;
+  /** Whether a secret is stored under `label`. */
+  has(label: string): boolean;
+  /** Zeroes and drops one entry. A no-op for an unknown label. */
+  wipe(label: string): void;
+  /** Redacts the scratch so material cannot leak through `JSON.stringify`. */
+  toJSON(): string;
+}
+
+/**
+ * The subset of the log extension's API the engine uses. Declared structurally
+ * so this package takes no dependency on `@algorandfoundation/log-store`.
+ */
+export interface MigrationLogger {
+  info(message: string, metadata?: Record<string, unknown>, context?: string): void;
+  warn(message: string, metadata?: Record<string, unknown>, context?: string): void;
+  error(message: string, metadata?: Record<string, unknown>, context?: string): void;
+}
+
+/** Second argument handed to every {@link Migration.up}. */
+export interface MigrationUtils {
+  /** Identity of the revision currently running. */
+  readonly revision: Readonly<{ module: string; id: number; name: string }>;
+  /** Secure scratch, wiped once this revision settles. */
+  readonly secrets: SecretScratch;
+  /** Present only when the provider carries a log extension. */
+  readonly log?: MigrationLogger;
+}
+
+/**
+ * A single forward-only data migration.
+ *
+ * `up` must be **idempotent** — running it twice must converge to the same
+ * state — and must be a no-op when there is nothing to migrate.
+ *
+ * @example
+ * ```typescript
+ * export const migration: Migration<MyStorage> = {
+ *   id: 1,
+ *   name: "add-scheme-field",
+ *   up: (storage) => {
+ *     for (const record of readAll(storage)) {
+ *       if (record.scheme) continue; // already migrated
+ *       write(storage, { ...record, scheme: "v2" });
+ *     }
+ *   },
+ * };
+ * ```
+ */
+export interface Migration<Ctx = unknown> {
+  /** Positive integer. Unique and strictly ascending within a module. */
+  id: number;
+  /** Human-readable name, used in logs and the report. */
+  name: string;
+  up(context: Ctx, utils: MigrationUtils): Promise<void> | void;
+}
+
+/** A module's registration: its identity, its context, and its revisions. */
+export interface MigrationModule<Ctx = unknown> {
+  /** Unique module id. Use the package name. */
+  module: string;
+  /** Resolved lazily — only called when the module has pending revisions. */
+  context: () => Ctx | Promise<Ctx>;
+  /** The module's revisions, ascending by id. */
+  migrations: readonly Migration<Ctx>[];
+}
+
+/** Durable record of which revision each module has reached. */
+export interface MigrationLedger {
+  /** Reads the whole map. An absent or unreadable ledger reads as `{}`. */
+  read(): Promise<Record<string, Revision>>;
+  /** Records `revision` as the latest applied for `module`. */
+  write(module: string, revision: Revision): Promise<void>;
+}
+
+/** A revision that was applied during a run. */
+export interface AppliedRevision {
+  module: string;
+  id: number;
+  name: string;
+}
+
+/** A failure recorded during a run. */
+export interface FailedRevision {
+  module: string;
+  /** Absent when the failure is module-level (invalid manifest, context error). */
+  id?: number;
+  /** Absent when the failure is module-level. */
+  name?: string;
+  error: Error;
+}
+
+/** A module whose ledger revision exceeds the highest revision it declares. */
+export interface AheadModule {
+  module: string;
+  ledgerRevision: number;
+  latestKnown: number;
+}
+
+/** The outcome of a migration run. */
+export interface MigrationReport {
+  applied: AppliedRevision[];
+  failed: FailedRevision[];
+  ahead: AheadModule[];
+}
+
+/** The API `WithMigrations` places on the provider as `provider.migrations`. */
+export interface MigrationsApi {
+  /** Registers a module. Called by opted-in extensions during construction. */
+  register<Ctx>(module: MigrationModule<Ctx>): void;
+  /** Promise of the first run. Rejects with `MigrationFailedError` on failure. */
+  readonly ready: Promise<MigrationReport>;
+  /** Starts the run if it has not started; returns the same promise as `ready`. */
+  run(): Promise<MigrationReport>;
+  /** Fires `"migrate"` once per revision, with `{ module, revision }`. */
+  readonly hooks: HookCollection<any>;
+}
+
+/** The shape `WithMigrations` contributes to the provider. */
+export interface MigrationsExtension {
+  migrations: MigrationsApi;
+}
+
+/** Provider options consumed by {@link MigrationsExtension}. */
+export interface MigrationsOptions extends ExtensionOptions {
+  migrations: {
+    /** Required. Where revisions are recorded. */
+    ledger: MigrationLedger;
+    /** Defaults to `true`. When `false`, nothing runs until `run()` is called. */
+    autoRun?: boolean;
+    /** Optional pre-built hook collection. */
+    hooks?: HookCollection<any>;
+  };
+}
+
+/**
+ * Minimal synchronous or asynchronous string key/value store, adapted by
+ * {@link MigrationLedger} implementations. Deliberately matches neither MMKV
+ * nor `localStorage` — a two-line lambda adapts either.
+ */
+export interface KeyValueStore {
+  get(key: string): string | null | undefined | Promise<string | null | undefined>;
+  set(key: string, value: string): void | Promise<void>;
+}
+
+/** Arguments for the pure runner. */
+export interface ApplyMigrationsOptions {
+  /** Registered modules, in registration order. */
+  registry: readonly MigrationModule<any>[];
+  ledger: MigrationLedger;
+  hooks?: HookCollection<any>;
+  log?: MigrationLogger;
+}

--- a/migrations/tsconfig.build.json
+++ b/migrations/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.bench.ts"]
+}

--- a/migrations/tsconfig.json
+++ b/migrations/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["es2022", "dom"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "esModuleInterop": false,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "declaration": true,
+    "sourceMap": true,
+    "declarationMap": true,
+    "isolatedDeclarations": true,
+    "allowSyntheticDefaultImports": false,
+    "allowUnreachableCode": false,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "noUncheckedIndexedAccess": false,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true
+  },
+  "include": ["src/**/*"]
+}

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
     "url": "git+https://github.com/algorandfoundation/wallet-provider-extensions.git"
   },
   "scripts": {
-    "build": "pnpm run build:releaser && pnpm run build:log && pnpm run build:stores && pnpm run build:extensions",
+    "build": "pnpm run build:releaser && pnpm run build:log && pnpm run build:migrations && pnpm run build:stores && pnpm run build:extensions",
     "build:releaser": "pnpm run --filter @algorandfoundation/package-releaser build",
     "build:log": "pnpm run --filter @algorandfoundation/log-store build",
+    "build:migrations": "pnpm run --filter @algorandfoundation/provider-migrations build",
     "build:stores": "pnpm run --filter @algorandfoundation/keystore-core build && pnpm run --filter @algorandfoundation/keystore-node build && pnpm run --filter @algorandfoundation/keystore-web build && pnpm run --filter @algorandfoundation/react-native-keystore build && pnpm run --filter @algorandfoundation/keystore build && pnpm run --filter @algorandfoundation/accounts-store build && pnpm run --filter @algorandfoundation/identities-store build",
     "build:extensions": "pnpm run --filter @algorandfoundation/accounts-keystore-extension build && pnpm run --filter @algorandfoundation/identities-keystore-extension build && pnpm run --filter @algorandfoundation/identities-extension build",
     "clean": "pnpm run -r --if-present clean && rm -rf coverage node_modules docs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,6 +260,9 @@ importers:
       '@algorandfoundation/log-store':
         specifier: workspace:*
         version: link:../../log
+      '@algorandfoundation/provider-migrations':
+        specifier: workspace:*
+        version: link:../../migrations
       '@algorandfoundation/react-native-keystore':
         specifier: workspace:*
         version: link:../../keystore/react-native
@@ -654,6 +657,9 @@ importers:
       '@algorandfoundation/package-releaser':
         specifier: workspace:^
         version: link:../../build
+      '@algorandfoundation/provider-migrations':
+        specifier: workspace:*
+        version: link:../../migrations
       falcon-1024:
         specifier: 'catalog:'
         version: 0.2.0
@@ -728,6 +734,22 @@ importers:
       before-after-hook:
         specifier: 'catalog:'
         version: 4.0.0
+
+  migrations:
+    dependencies:
+      '@algorandfoundation/wallet-provider':
+        specifier: 'catalog:'
+        version: 1.0.0-canary.5
+    devDependencies:
+      '@algorandfoundation/package-releaser':
+        specifier: workspace:^
+        version: link:../build
+      before-after-hook:
+        specifier: 'catalog:'
+        version: 4.0.0
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.2(@types/node@25.5.0)(jsdom@20.0.3(canvas@2.11.2))(vite@6.4.1(@types/node@25.5.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.23.1)(yaml@2.8.3))
 
 packages:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - "log"
+  - "migrations"
   - "accounts/**"
   - "keystore/**"
   - "identities/**"

--- a/typedoc.json
+++ b/typedoc.json
@@ -12,7 +12,8 @@
     "identities/extension",
     "identities/store",
     "identities/keystore-extension",
-    "log"
+    "log",
+    "migrations"
   ],
   "externalSymbolLinkMappings": {
     "@algorandfoundation/xhd-wallet-api": {


### PR DESCRIPTION
## Description

Adds an opt-in data-migrations engine so packages in this repo can ship a versioned, tracked migration alongside a breaking change, instead of hand-rolling a startup fix-up pass.

The motivating case already exists in-tree: `migrateLegacyPasskeys` in `keystore/react-native/src/storage/driver.ts` ran unconditionally on **every** engine start, kept safe only by re-checking a metadata flag, with no record of what had been applied and no way to add a second pass without repeating the pattern. This PR turns it into revision `0001` behind the engine.

### How it works

`WithMigrations` is a Wallet Provider extension placed **first** in the extensions array. Three properties fall out of `Provider`'s synchronous constructor:

1. Extensions are applied in order, so `provider.migrations` exists for every later extension.
2. The run is scheduled as a **microtask**, which cannot fire until the synchronous `EXTENSIONS.forEach` loop finishes — so the registry is always complete before the first revision executes.
3. Opted-in packages need only `import type { Migration }`, and `verbatimModuleSyntax` erases it — so they carry **zero runtime dependency** on the new package.

```typescript
const MyProvider = Provider.withExtensions([WithMigrations, WithKeyStore]);
const provider = new MyProvider(config, {
  migrations: { ledger: keyValueLedger({ get: (k) => mmkv.getString(k), set: (k, v) => mmkv.set(k, v) }) },
  keystore: { store, hooks },
});
await provider.migrations.ready;
```

Packages self-register through the existing optional-dependency probe:

```typescript
provider.migrations?.register({ module: "@algorandfoundation/react-native-keystore", context: () => storage, migrations });
```

### Design decisions

- **Storage-agnostic.** The engine sequences revisions and records a ledger; it knows nothing about storage. Each module declares its own opaque context type, so IndexedDB, MMKV and a sealed file all work without a lowest-common-denominator interface.
- **Ledger written per revision, never batched.** A killed run resumes exactly where it stopped.
- **Forward-only, always from revision zero.** Migrations must tolerate empty data — correct for existing installs, a cheap no-op for fresh ones.
- **Per-module failure isolation.** A failing revision halts only its own module; the ledger keeps that module's last successful revision; other modules still run; then `ready` rejects with an aggregate error.
- **A downgrade is not fatal.** A ledger ahead of the installed code is reported and warned about, not thrown — bricking an app on a downgrade is worse.
- **Security first.** Each revision gets a run-scoped `SecretScratch` for key material in flight between storages: bytes only (never strings), single-ownership with no defensive copy, zeroed in a `finally` whether the revision succeeds or throws, use-after-wipe throws, and non-serializable so material cannot reach a log line or `JSON.stringify`. Hook payloads carry `{ module, revision }` only — never the context or the scratch.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**Breaking:** `@algorandfoundation/react-native-keystore` no longer auto-flags legacy passkeys on engine start. That pass is now revision `0001` and runs only when `WithMigrations` is installed on the provider. Consumers must install `@algorandfoundation/provider-migrations` (an optional peer, so it is not pulled in automatically) and add `WithMigrations` first. Documented in that package's README and carried as a `BREAKING CHANGE:` footer on `7ab0e90`.

## How Has This Been Tested?

`pnpm run build && pnpm install && pnpm run lint && pnpm run fmt:check && pnpm test` — mirroring `.github/workflows/integrate.yml`.

- [x] **303 tests passing, 0 failures** (baseline on `main` was 201 — 102 new)
- [x] `@algorandfoundation/provider-migrations`: 87 tests — runner sequencing, per-revision ledger writes, failure isolation, downgrade handling, hook payload isolation, scratch lifetime, ledger adapters, manifest validation, extension wiring
- [x] `@algorandfoundation/react-native-keystore`: 72 tests (was 57) — the `before` gate, revision 0001 including `assertIdempotent`, manifest validity, and storage-identity between the migration context and the engine
- [x] Build, lint (0 errors) and `fmt:check` all green
- [x] `examples/react-native-wallet` typechecks with the engine wired end to end

Three separate rounds of review on this branch found tests that would have **passed vacuously** — assertions inside an unreached `.catch`, a timing test whose confounder made it pass with the feature removed, and an idempotency helper that reported success for `Map`/`Set` snapshots. Each was fixed and then verified by deliberately breaking the behaviour and confirming the test fails.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Notes for reviewers

Worth a close look:

- **`migrations/src/apply.ts`** — the runner. The ledger write sits inside the per-revision loop deliberately; moving it out breaks crash-resume.
- **`migrations/src/secrets.ts`** — `put` takes ownership and does **not** copy. A defensive copy here would leave a second plaintext buffer alive, defeating the module's purpose.
- **`keystore/react-native/src/engine.ts`** — the `before` gate. Without it, the migration races core's `ready`, which is already in flight awaiting `driver.ready` before hydrating.
- **`keystore/react-native/src/extension.ts`** — `storage` is resolved once and used for both the migration context and the engine. If those ever diverge, the migration rewrites a store the keystore never reads, silently.
