### PR TITLE
feat: keystore migrations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "passkeys/react-native-autofill"]
+	path = passkeys/react-native-autofill
+	url = git@github.com:algorandfoundation/react-native-passkey-autofill.git

--- a/keystore/react-native/README.md
+++ b/keystore/react-native/README.md
@@ -36,6 +36,28 @@ is present on the provider.
 > Without it, legacy passkeys are never flagged and the UI cannot prompt users to
 > recreate them.
 
+### Revisions
+
+| Revision | Name                   | What it does                                                                                                                                                                                                                                                                                                                        |
+| -------- | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `0001`   | `flag-legacy-passkeys` | Flags passkeys derived from the XHD root before the deterministic-P256 split as needing migration. Metadata-only — nothing is decrypted and no biometric prompt fires.                                                                                                                                                              |
+| `0002`   | `adopt-flat-records`   | Adopts legacy **flat** `<id>` records — one sealed blob per key, as written by the deprecated `commit()` helper and by older native passkey AutoFill credential providers sharing the same MMKV instance — into the split `k/<id>` + `m/<id>` layout the driver reads, then re-runs the passkey flag pass over what became visible. |
+
+> Revision `0002` decrypts material, so it reads the master key **once** for the
+> whole pass — the only step that can raise a biometric/passcode prompt, and only
+> when at least one flat record actually exists. A record it cannot decrypt (or
+> that carries no `privateKey`/`seed` material, e.g. a native credential wrapped
+> by a biometric cipher this package cannot open) is left untouched and reported
+> through the provider's log — never deleted.
+>
+> Because `0002` runs **once per ledger**, anything that keeps writing flat
+> records after it has run stays invisible to the driver. Update the native
+> passkey AutoFill provider to a version that writes the split `k/` + `m/`
+> layout **before** (or together with) shipping this migration —
+> `@algorandfoundation/react-native-passkey-autofill` does so from
+> `1.0.0-canary.23` (see its `KeystoreRecords`/`PasskeyCredentialStore`
+> record-format owners).
+
 ## Why This Exists
 
 Building a non-custodial wallet requires a **secure, isolated key vault**. The Keystore Extension separates key management from wallet logic:

--- a/keystore/react-native/src/extension.test.ts
+++ b/keystore/react-native/src/extension.test.ts
@@ -229,7 +229,7 @@ describe("WithKeyStore — migrations registration", () => {
     expect(register).toHaveBeenCalledTimes(1);
     const registered = register.mock.calls[0]![0];
     expect(registered.module).toBe("@algorandfoundation/react-native-keystore");
-    expect(registered.migrations.map((m: { id: number }) => m.id)).toEqual([1]);
+    expect(registered.migrations.map((m: { id: number }) => m.id)).toEqual([1, 2]);
   });
 
   it("is a no-op when the provider has no migrations extension", () => {

--- a/keystore/react-native/src/extension.ts
+++ b/keystore/react-native/src/extension.ts
@@ -4,8 +4,9 @@ import type { Extension, Provider } from "@algorandfoundation/wallet-provider";
 
 import { createReactNativeKeyStore } from "./engine.ts";
 import { migrations } from "./migrations/index.ts";
+import { readMasterKey } from "./storage/crypto.ts";
 import { storage as defaultStorage } from "./storage/state.ts";
-import type { ReactKeystoreOptions } from "./types.ts";
+import type { KeystoreMigrationContext, ReactKeystoreOptions } from "./types.ts";
 
 /**
  * Wallet Provider Extension that adds Keystore functionality.
@@ -95,7 +96,15 @@ export const WithKeyStore: Extension<KeyStoreExtension> = (
   }
   migrationsApi?.register({
     module: "@algorandfoundation/react-native-keystore",
-    context: () => storage,
+    // Resolved lazily by the runner, only when a revision is pending. Revision
+    // 0002 opens and re-seals material, so the context carries the host
+    // `subtle` and the master-key read alongside the storage instance.
+    context: (): KeystoreMigrationContext => ({
+      storage,
+      subtle: options.keystore.subtle as SubtleCrypto,
+      masterKeyForRead: (auth) => readMasterKey(auth ?? options.keystore.authentication),
+      authentication: options.keystore.authentication,
+    }),
     migrations,
   });
 

--- a/keystore/react-native/src/migrations/0001-flag-legacy-passkeys.test.ts
+++ b/keystore/react-native/src/migrations/0001-flag-legacy-passkeys.test.ts
@@ -1,7 +1,7 @@
 import { createSecretScratch } from "@algorandfoundation/provider-migrations";
 import { assertIdempotent } from "@algorandfoundation/provider-migrations/testing";
 import { describe, expect, it } from "vitest";
-import { memoryStorage, seedLegacyPasskey } from "../storage/__fixtures__.ts";
+import { memoryStorage, migrationContext, seedLegacyPasskey } from "../storage/__fixtures__.ts";
 import { PASSKEY_MIGRATION_NEEDED } from "../storage/driver.ts";
 import { migration } from "./0001-flag-legacy-passkeys.ts";
 
@@ -17,7 +17,7 @@ describe("revision 0001 — flag-legacy-passkeys", () => {
 
     const { scratch, wipeAll } = createSecretScratch();
     try {
-      await migration.up(storage, {
+      await migration.up(migrationContext(storage), {
         revision: { module: "test", id: 1, name: "flag-legacy-passkeys" },
         secrets: scratch,
       });
@@ -50,17 +50,17 @@ describe("revision 0001 — flag-legacy-passkeys", () => {
             version: 1,
           }),
         );
-        return storage;
+        return migrationContext(storage);
       },
-      snapshot: (storage) => (storage as ReturnType<typeof memoryStorage>).entries(),
+      snapshot: (ctx) => (ctx.storage as ReturnType<typeof memoryStorage>).entries(),
     });
   });
 
   it("is a no-op on empty storage", async () => {
     await assertIdempotent({
       migration,
-      context: () => memoryStorage(),
-      snapshot: (storage) => (storage as ReturnType<typeof memoryStorage>).entries(),
+      context: () => migrationContext(memoryStorage()),
+      snapshot: (ctx) => (ctx.storage as ReturnType<typeof memoryStorage>).entries(),
     });
   });
 });

--- a/keystore/react-native/src/migrations/0001-flag-legacy-passkeys.ts
+++ b/keystore/react-native/src/migrations/0001-flag-legacy-passkeys.ts
@@ -1,6 +1,6 @@
 import type { Migration } from "@algorandfoundation/provider-migrations";
 import { migrateLegacyPasskeys } from "../storage/driver.ts";
-import type { KeychainStorage } from "../storage/driver.ts";
+import type { KeystoreMigrationContext } from "../types.ts";
 
 /**
  * Flags legacy passkeys — those derived from the XHD root before the
@@ -13,10 +13,10 @@ import type { KeychainStorage } from "../storage/driver.ts";
  * biometric prompt fires. It is idempotent — an already-flagged record and a
  * new-scheme passkey are both skipped — and a no-op on empty storage.
  */
-export const migration: Migration<KeychainStorage> = {
+export const migration: Migration<KeystoreMigrationContext> = {
   id: 1,
   name: "flag-legacy-passkeys",
-  up: (storage: KeychainStorage): void => {
+  up: ({ storage }: KeystoreMigrationContext): void => {
     migrateLegacyPasskeys(storage);
   },
 };

--- a/keystore/react-native/src/migrations/0002-adopt-flat-records.test.ts
+++ b/keystore/react-native/src/migrations/0002-adopt-flat-records.test.ts
@@ -1,0 +1,154 @@
+import { createSecretScratch } from "@algorandfoundation/provider-migrations";
+import type { MigrationUtils } from "@algorandfoundation/provider-migrations";
+import { assertIdempotent } from "@algorandfoundation/provider-migrations/testing";
+import { base64 } from "@scure/base";
+import { describe, expect, it, vi } from "vitest";
+import { memoryStorage, migrationContext } from "../storage/__fixtures__.ts";
+import { openData, sealData } from "../storage/crypto.ts";
+import { PASSKEY_MIGRATION_NEEDED } from "../storage/driver.ts";
+import { encode } from "../storage/state.ts";
+import { migration } from "./0002-adopt-flat-records.ts";
+
+const subtle = globalThis.crypto.subtle;
+
+const masterKey = Buffer.alloc(32, 5);
+// Fresh copy per call, like the production `readMasterKey`: the pass zeroes
+// the buffer it receives once it's done with it.
+const masterKeyForRead = async () => Buffer.from(masterKey);
+
+/** Runs the revision the way `applyMigrations` would, with a wiped scratch. */
+async function runRevision(
+  context: ReturnType<typeof migrationContext>,
+  log?: MigrationUtils["log"],
+): Promise<void> {
+  const { scratch, wipeAll } = createSecretScratch();
+  try {
+    await migration.up(context, {
+      revision: { module: "test", id: 2, name: "adopt-flat-records" },
+      secrets: scratch,
+      log,
+    });
+  } finally {
+    wipeAll();
+  }
+}
+
+describe("revision 0002 — adopt-flat-records", () => {
+  it("is revision 2", () => {
+    expect(migration.id).toBe(2);
+    expect(migration.name).toBe("adopt-flat-records");
+  });
+
+  it("adopts a flat record into the split layout, keeping material openable", async () => {
+    const storage = memoryStorage();
+    storage.set(
+      "legacy-1",
+      await sealData(
+        subtle,
+        masterKey,
+        encode({
+          id: "legacy-1",
+          type: "ed25519",
+          algorithm: "EdDSA",
+          extractable: false,
+          keyUsages: ["sign", "verify"],
+          privateKey: new Uint8Array([9, 8, 7]),
+          version: 1,
+        } as any),
+      ),
+    );
+
+    await runRevision(migrationContext(storage, { masterKeyForRead }));
+
+    expect(storage.getString("legacy-1")).toBeUndefined();
+    expect(JSON.parse(storage.getString("k/legacy-1") as string).id).toBe("legacy-1");
+    const opened = await openData(subtle, masterKey, storage.getString("m/legacy-1") as string);
+    expect(base64.decode(opened)).toEqual(new Uint8Array([9, 8, 7]));
+  });
+
+  it("closes the 0001 gap: a legacy passkey that was still flat gets flagged after adoption", async () => {
+    const storage = memoryStorage();
+    // A pre-dp256-split passkey (no `scheme` in metadata) still stored flat —
+    // invisible to revision 0001's `k/` scan when it ran.
+    storage.set(
+      "pk-flat",
+      await sealData(
+        subtle,
+        masterKey,
+        encode({
+          id: "pk-flat",
+          type: "hd-derived-p256",
+          algorithm: "P256",
+          extractable: false,
+          keyUsages: ["sign", "verify"],
+          privateKey: new Uint8Array([1, 2, 3]),
+          metadata: { storage: "none", origin: "https://example.com", userHandle: "user-123" },
+          version: 1,
+        } as any),
+      ),
+    );
+
+    await runRevision(migrationContext(storage, { masterKeyForRead }));
+
+    const meta = JSON.parse(storage.getString("k/pk-flat") as string);
+    expect(meta.metadata.migration).toBe(PASSKEY_MIGRATION_NEEDED);
+    expect(meta.metadata.origin).toBe("https://example.com");
+  });
+
+  it("reports skipped records through the log without failing the revision", async () => {
+    const storage = memoryStorage();
+    storage.set("corrupt", "{not sealed}");
+    const warn = vi.fn();
+
+    await expect(
+      runRevision(migrationContext(storage, { masterKeyForRead }), {
+        info: vi.fn(),
+        warn,
+        error: vi.fn(),
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]![0]).toContain('"corrupt"');
+    // The record is left untouched for a later pass or manual recovery.
+    expect(storage.getString("corrupt")).toBe("{not sealed}");
+  });
+
+  it("is idempotent, including over records it must skip", async () => {
+    await assertIdempotent({
+      migration,
+      context: async () => {
+        const storage = memoryStorage();
+        storage.set(
+          "legacy-1",
+          await sealData(
+            subtle,
+            masterKey,
+            encode({
+              id: "legacy-1",
+              type: "seed",
+              algorithm: "raw",
+              extractable: false,
+              keyUsages: ["deriveBits", "deriveKey"],
+              seed: new Uint8Array([4, 4, 4]),
+              version: 1,
+            } as any),
+          ),
+        );
+        storage.set("corrupt", "{not sealed}");
+        return migrationContext(storage, { masterKeyForRead });
+      },
+      snapshot: (ctx) => (ctx.storage as ReturnType<typeof memoryStorage>).entries(),
+    });
+  });
+
+  it("is a no-op on empty storage and never touches the master key", async () => {
+    const masterKeySpy = vi.fn(masterKeyForRead);
+    await assertIdempotent({
+      migration,
+      context: () => migrationContext(memoryStorage(), { masterKeyForRead: masterKeySpy }),
+      snapshot: (ctx) => (ctx.storage as ReturnType<typeof memoryStorage>).entries(),
+    });
+    expect(masterKeySpy).not.toHaveBeenCalled();
+  });
+});

--- a/keystore/react-native/src/migrations/0002-adopt-flat-records.ts
+++ b/keystore/react-native/src/migrations/0002-adopt-flat-records.ts
@@ -1,0 +1,66 @@
+import type { Migration, MigrationUtils } from "@algorandfoundation/provider-migrations";
+import { migrateLegacyPasskeys } from "../storage/driver.ts";
+import { adoptLegacyRecords } from "../storage/legacy.ts";
+import type { KeystoreMigrationContext } from "../types.ts";
+
+/**
+ * Adopts legacy **flat** `<id>` records into the split `k/<id>` + `m/<id>`
+ * layout the Keychain/MMKV driver reads.
+ *
+ * Before the driver split, a key was one flat MMKV entry keyed by its bare id,
+ * whose sealed plaintext held metadata AND private material together. Two
+ * writers produced that shape: this package's deprecated `commit()` helper and
+ * the native passkey AutoFill credential provider, which writes into the same
+ * MMKV instance from a separate process. Neither shape is visible to the
+ * driver's `listMeta()` (it only scans `k/`), so without this revision those
+ * records silently vanish from the reactive store after an upgrade.
+ *
+ * Unlike revision `0001` this **decrypts material**: each flat record is
+ * opened with the master key (one read for the whole pass — the only step
+ * that can raise a biometric/passcode prompt), its material re-sealed under
+ * `m/<id>` and its metadata written in plaintext under `k/<id>`. Decrypted
+ * buffers never leave {@link adoptLegacyRecords}, which zeroes them in its own
+ * `finally` — the run-scoped secret scratch is therefore not needed here.
+ *
+ * A record that cannot be decoded, decrypted, or carries no `privateKey`/`seed`
+ * material (e.g. a native credential wrapped by a biometric cipher this
+ * package cannot open) is left untouched and reported through the provider's
+ * log — never deleted, and never fatal for the revision.
+ *
+ * Finally the (idempotent, metadata-only) legacy-passkey flag pass runs again:
+ * revision `0001` executed before any flat record was visible under `k/`, so
+ * a legacy passkey that was still flat at that point would otherwise escape
+ * flagging forever — the ledger records `0001` as applied and never re-runs it.
+ */
+export const migration: Migration<KeystoreMigrationContext> = {
+  id: 2,
+  name: "adopt-flat-records",
+  up: async (context: KeystoreMigrationContext, utils: MigrationUtils): Promise<void> => {
+    const { adopted, skipped } = await adoptLegacyRecords(context);
+
+    for (const failure of skipped) {
+      utils.log?.warn(
+        `Could not adopt flat record "${failure.id}"; left untouched`,
+        {
+          module: utils.revision.module,
+          error: failure.error instanceof Error ? failure.error.message : String(failure.error),
+        },
+        utils.revision.module,
+      );
+    }
+    if (adopted.length > 0) {
+      utils.log?.info(
+        `Adopted ${adopted.length} flat record(s) into the split k/ + m/ layout`,
+        { module: utils.revision.module },
+        utils.revision.module,
+      );
+    }
+
+    // Newly adopted records may include legacy passkeys revision 0001 could
+    // not see (they were still flat when it ran). The pass is idempotent, so
+    // re-running it here is safe and closes that gap.
+    migrateLegacyPasskeys(context.storage);
+  },
+};
+
+export default migration;

--- a/keystore/react-native/src/migrations/index.test.ts
+++ b/keystore/react-native/src/migrations/index.test.ts
@@ -9,7 +9,7 @@ describe("migrations manifest", () => {
     ).not.toThrow();
   });
 
-  it("declares at least revision 1", () => {
-    expect(migrations.map((m) => m.id)).toContain(1);
+  it("declares revisions 1 and 2, in order", () => {
+    expect(migrations.map((m) => m.id)).toEqual([1, 2]);
   });
 });

--- a/keystore/react-native/src/migrations/index.ts
+++ b/keystore/react-native/src/migrations/index.ts
@@ -1,6 +1,7 @@
 import type { Migration } from "@algorandfoundation/provider-migrations";
-import type { KeychainStorage } from "../storage/driver.ts";
+import type { KeystoreMigrationContext } from "../types.ts";
 import { migration as r0001 } from "./0001-flag-legacy-passkeys.ts";
+import { migration as r0002 } from "./0002-adopt-flat-records.ts";
 
 /**
  * Every revision this package declares, ascending by id.
@@ -8,4 +9,4 @@ import { migration as r0001 } from "./0001-flag-legacy-passkeys.ts";
  * Registered with the provider by {@link import("../extension.ts").WithKeyStore}
  * when a migrations extension is present.
  */
-export const migrations: readonly Migration<KeychainStorage>[] = [r0001];
+export const migrations: readonly Migration<KeystoreMigrationContext>[] = [r0001, r0002];

--- a/keystore/react-native/src/storage/__fixtures__.ts
+++ b/keystore/react-native/src/storage/__fixtures__.ts
@@ -5,6 +5,8 @@
  * test-only helpers and must never ship in `dist/`.
  */
 
+import { MasterKeyNotFoundError } from "../errors.ts";
+import type { KeystoreMigrationContext } from "../types.ts";
 import type { KeychainStorage } from "./driver.ts";
 
 /** A fresh in-memory MMKV-style store per test (real Keychain master is mocked). */
@@ -20,6 +22,26 @@ export function memoryStorage(): KeychainStorage & { entries(): [string, string]
     },
     getAllKeys: () => [...map.keys()],
     entries: () => [...map.entries()],
+  };
+}
+
+/**
+ * A {@link KeystoreMigrationContext} over `storage` for driving migration
+ * revisions in tests. By default `masterKeyForRead` reports that no master key
+ * exists (the fresh-install case); pass an override for tests that exercise
+ * material adoption.
+ */
+export function migrationContext(
+  storage: KeychainStorage,
+  overrides: Partial<KeystoreMigrationContext> = {},
+): KeystoreMigrationContext {
+  return {
+    storage,
+    subtle: globalThis.crypto.subtle,
+    masterKeyForRead: async () => {
+      throw new MasterKeyNotFoundError();
+    },
+    ...overrides,
   };
 }
 

--- a/keystore/react-native/src/storage/driver.ts
+++ b/keystore/react-native/src/storage/driver.ts
@@ -30,9 +30,10 @@ import { base64 } from "@scure/base";
 
 import type { AuthenticationOptions } from "../types.ts";
 
-/** Storage-key prefixes so material and metadata share one MMKV instance. */
-const MATERIAL_PREFIX = "m/";
-const METADATA_PREFIX = "k/";
+/** Storage-key prefix for sealed material records (`m/<id>`). */
+export const MATERIAL_PREFIX = "m/";
+/** Storage-key prefix for plaintext metadata records (`k/<id>`). */
+export const METADATA_PREFIX = "k/";
 
 /**
  * The minimal MMKV-style synchronous key/value surface the driver relies on.
@@ -89,7 +90,7 @@ const CAPABILITIES: DriverCapabilities = {
 };
 
 /** Serializes {@link Key} metadata to a string, base64-encoding any bytes. */
-function serializeKey(key: Key): string {
+export function serializeKey(key: Key): string {
   return JSON.stringify(key, (_k, value) => {
     if (value instanceof Uint8Array) return { $u8: base64.encode(value) };
     return value;

--- a/keystore/react-native/src/storage/index.ts
+++ b/keystore/react-native/src/storage/index.ts
@@ -1,3 +1,4 @@
 export * from "./crypto.ts";
 export * from "./driver.ts";
+export * from "./legacy.ts";
 export * from "./state.ts";

--- a/keystore/react-native/src/storage/legacy.test.ts
+++ b/keystore/react-native/src/storage/legacy.test.ts
@@ -1,0 +1,185 @@
+import type { KeyData } from "@algorandfoundation/keystore-core";
+import { base64 } from "@scure/base";
+import { createCipheriv } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+
+import { MasterKeyNotFoundError } from "../errors.ts";
+import { memoryStorage } from "./__fixtures__.ts";
+import { openData, sealData } from "./crypto.ts";
+import { adoptLegacyRecords } from "./legacy.ts";
+import { encode } from "./state.ts";
+
+const subtle = globalThis.crypto.subtle;
+
+/**
+ * Seals `data` with the legacy `{iv, tag, content}` envelope (auth tag stored
+ * separately, as `react-native-quick-crypto`'s old `createCipheriv` scheme did).
+ */
+function sealLegacyEnvelope(key: Buffer, data: string): string {
+  const iv = Buffer.alloc(12, 7);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  let content = cipher.update(data, "utf8", "base64");
+  content += cipher.final("base64");
+  return JSON.stringify({
+    iv: iv.toString("base64"),
+    tag: cipher.getAuthTag().toString("base64"),
+    content,
+  });
+}
+
+describe("adoptLegacyRecords", () => {
+  const masterKey = Buffer.alloc(32, 5);
+  // Mirrors the production `readMasterKey`, which always hands back a fresh
+  // copy: `adoptLegacyRecords` zeroes the buffer it receives once it's done,
+  // so a mock that returned the very same instance every call would corrupt
+  // `masterKey` out from under the rest of a test.
+  const masterKeyForRead = async () => Buffer.from(masterKey);
+
+  it("adopts a flat legacy {iv,tag,content} record into k/+m/, keeping material openable", async () => {
+    const storage = memoryStorage();
+    const keyData: KeyData = {
+      id: "legacy-1",
+      type: "ed25519",
+      algorithm: "EdDSA",
+      extractable: false,
+      keyUsages: ["sign", "verify"],
+      publicKey: new Uint8Array([1, 2, 3, 4]),
+      privateKey: new Uint8Array([9, 8, 7, 6, 5]),
+      version: 1,
+    } as unknown as KeyData;
+    storage.set("legacy-1", sealLegacyEnvelope(masterKey, encode(keyData)));
+
+    const result = await adoptLegacyRecords({ storage, subtle, masterKeyForRead });
+
+    expect(result.adopted).toEqual(["legacy-1"]);
+    expect(result.skipped).toEqual([]);
+
+    // The flat record is gone; the split pair exists instead.
+    expect(storage.getString("legacy-1")).toBeUndefined();
+    const metaRaw = storage.getString("k/legacy-1");
+    expect(metaRaw).toBeDefined();
+    const meta = JSON.parse(metaRaw as string);
+    expect(meta.id).toBe("legacy-1");
+    expect(meta.type).toBe("ed25519");
+    expect(meta.privateKey).toBeUndefined();
+
+    // Material is present and still openable, matching the original bytes.
+    const sealedMaterial = storage.getString("m/legacy-1");
+    expect(sealedMaterial).toBeDefined();
+    const opened = await openData(subtle, masterKey, sealedMaterial as string);
+    expect(base64.decode(opened)).toEqual(new Uint8Array([9, 8, 7, 6, 5]));
+  });
+
+  it("is idempotent: a second pass over already-adopted records is a no-op", async () => {
+    const storage = memoryStorage();
+    const keyData: KeyData = {
+      id: "legacy-2",
+      type: "seed",
+      algorithm: "raw",
+      extractable: false,
+      keyUsages: ["deriveBits", "deriveKey"],
+      seed: new Uint8Array([1, 1, 1, 1]),
+      version: 1,
+    } as unknown as KeyData;
+    storage.set("legacy-2", await sealData(subtle, masterKey, encode(keyData)));
+
+    const first = await adoptLegacyRecords({ storage, subtle, masterKeyForRead });
+    expect(first.adopted).toEqual(["legacy-2"]);
+
+    const before = { k: storage.getString("k/legacy-2"), m: storage.getString("m/legacy-2") };
+    const second = await adoptLegacyRecords({ storage, subtle, masterKeyForRead });
+    expect(second.adopted).toEqual([]);
+    expect(second.skipped).toEqual([]);
+    // Nothing was rewritten on the no-op pass.
+    expect(storage.getString("k/legacy-2")).toBe(before.k);
+    expect(storage.getString("m/legacy-2")).toBe(before.m);
+  });
+
+  it("skips a corrupt/undecryptable flat record without deleting it or aborting the pass", async () => {
+    const storage = memoryStorage();
+    storage.set("corrupt", "{not valid sealed data}");
+
+    const goodKeyData: KeyData = {
+      id: "good",
+      type: "seed",
+      algorithm: "raw",
+      extractable: false,
+      keyUsages: ["deriveBits", "deriveKey"],
+      seed: new Uint8Array([4, 4, 4, 4]),
+      version: 1,
+    } as unknown as KeyData;
+    storage.set("good", await sealData(subtle, masterKey, encode(goodKeyData)));
+
+    const result = await adoptLegacyRecords({ storage, subtle, masterKeyForRead });
+
+    expect(result.adopted).toEqual(["good"]);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]?.id).toBe("corrupt");
+
+    // The corrupt record is untouched, not removed.
+    expect(storage.getString("corrupt")).toBe("{not valid sealed data}");
+    expect(storage.getString("k/corrupt")).toBeUndefined();
+    expect(storage.getString("m/corrupt")).toBeUndefined();
+  });
+
+  it("skips a record with no recoverable privateKey/seed material without deleting it", async () => {
+    const storage = memoryStorage();
+    // Simulates a native credential record protected by a biometric cipher
+    // this package cannot open (no plain `privateKey`/`seed` field).
+    const record = { id: "native-cred", type: "hd-derived-p256", privateKeyEnc: "opaque" };
+    storage.set("native-cred", await sealData(subtle, masterKey, JSON.stringify(record)));
+
+    const result = await adoptLegacyRecords({ storage, subtle, masterKeyForRead });
+
+    expect(result.adopted).toEqual([]);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]?.id).toBe("native-cred");
+    expect(storage.getString("native-cred")).toBeDefined();
+  });
+
+  it("requests no master key and migrates nothing when there are no flat records", async () => {
+    const storage = memoryStorage();
+    storage.set("k/already-migrated", JSON.stringify({ id: "already-migrated" }));
+    storage.set("m/already-migrated", "sealed-material");
+
+    const masterKeySpy = vi.fn(masterKeyForRead);
+    const result = await adoptLegacyRecords({ storage, subtle, masterKeyForRead: masterKeySpy });
+
+    expect(result).toEqual({ adopted: [], skipped: [] });
+    expect(masterKeySpy).not.toHaveBeenCalled();
+  });
+
+  it("never treats the migrations ledger blob as a flat record", async () => {
+    const storage = memoryStorage();
+    // A key/value ledger pointed at this MMKV instance writes its revision map
+    // under this well-known key; it must be neither adopted nor reported, and
+    // must not trigger a master-key read on its own.
+    storage.set(
+      "@algorandfoundation/provider-migrations",
+      JSON.stringify({ "@scope/pkg": { id: 1, name: "first", appliedAt: "now" } }),
+    );
+
+    const masterKeySpy = vi.fn(masterKeyForRead);
+    const result = await adoptLegacyRecords({ storage, subtle, masterKeyForRead: masterKeySpy });
+
+    expect(result).toEqual({ adopted: [], skipped: [] });
+    expect(masterKeySpy).not.toHaveBeenCalled();
+  });
+
+  it("treats a missing master key as nothing-to-migrate when flat records exist but no master key was ever created", async () => {
+    const storage = memoryStorage();
+    storage.set("legacy-3", "some-sealed-blob");
+
+    const result = await adoptLegacyRecords({
+      storage,
+      subtle,
+      masterKeyForRead: async () => {
+        throw new MasterKeyNotFoundError();
+      },
+    });
+
+    expect(result).toEqual({ adopted: [], skipped: [] });
+    // The flat record is left untouched — nothing was migrated.
+    expect(storage.getString("legacy-3")).toBe("some-sealed-blob");
+  });
+});

--- a/keystore/react-native/src/storage/legacy.ts
+++ b/keystore/react-native/src/storage/legacy.ts
@@ -1,0 +1,187 @@
+/**
+ * Adoption of the legacy **flat** `<id>` record layout (one sealed blob per
+ * key, holding both metadata and material — see `commit`/`fetchSecret` in
+ * `state.ts`) into the `k/<id>` + `m/<id>` pair {@link createKeychainDriver}
+ * understands.
+ *
+ * Two independent writers still produce flat records: the deprecated
+ * `commit()` helper (still called by consumers doing in-place metadata edits)
+ * and the native Android/iOS passkey credential provider, which writes
+ * straight into this MMKV instance from a separate process using the very
+ * same shape. Neither is visible to {@link createKeychainDriver}'s
+ * `listMeta()` (it only scans `k/`), so without this pass those records are
+ * silently invisible to the reactive store.
+ *
+ * The pass is exposed to applications as tracked revision `0002`
+ * (`adopt-flat-records`) of this package's migration manifest — see
+ * `../migrations/0002-adopt-flat-records.ts` — rather than running ad hoc on
+ * every engine start.
+ */
+
+import type { Key, KeyData } from "@algorandfoundation/keystore-core";
+import { clearBuffer } from "@algorandfoundation/wallet-provider";
+import { base64 } from "@scure/base";
+
+import { MasterKeyNotFoundError } from "../errors.ts";
+import type { AuthenticationOptions } from "../types.ts";
+import { openData, sealData } from "./crypto.ts";
+import { MATERIAL_PREFIX, METADATA_PREFIX, serializeKey } from "./driver.ts";
+import type { KeychainStorage } from "./driver.ts";
+import { decode } from "./state.ts";
+
+/** A flat record that could not be adopted this pass, and why. */
+export interface LegacyAdoptionFailure {
+  /** The flat record's MMKV key (its key id). */
+  id: string;
+  /** The error that stopped adoption for this record. */
+  error: unknown;
+}
+
+/** Outcome of a single {@link adoptLegacyRecords} pass. */
+export interface LegacyAdoptionResult {
+  /** Ids successfully split into `k/<id>` + `m/<id>` (flat record removed). */
+  adopted: string[];
+  /** Records left untouched — corrupt, undecryptable, or carrying no material. */
+  skipped: LegacyAdoptionFailure[];
+}
+
+/** Dependencies for {@link adoptLegacyRecords}. */
+export interface LegacyAdoptionDeps {
+  /** The MMKV-style store holding both the flat records and the `k/`/`m/` pairs. */
+  storage: KeychainStorage;
+  /** Host Subtle implementation used to open/re-seal material. */
+  subtle: SubtleCrypto;
+  /**
+   * Resolves the existing master key for a **read**. Must not create one —
+   * a missing master key with no flat records around is the ordinary fresh
+   * install, not an error.
+   */
+  masterKeyForRead: (options?: AuthenticationOptions) => Promise<Uint8Array>;
+  /** Authentication policy forwarded to {@link LegacyAdoptionDeps.masterKeyForRead}. */
+  authentication?: AuthenticationOptions;
+}
+
+/**
+ * The default storage key `@algorandfoundation/provider-migrations`' key/value
+ * ledger serialises its revision map under. Excluded defensively: applications
+ * are advised to keep the ledger in its own MMKV instance, but one pointed at
+ * this keystore's instance must never have its ledger blob treated as a flat
+ * record — it would be reported as skipped and could raise a needless unlock
+ * prompt. Kept as a literal so the storage layer stays free of any runtime
+ * dependency on the migrations package.
+ */
+const MIGRATIONS_LEDGER_KEY = "@algorandfoundation/provider-migrations";
+
+/** True for MMKV keys this pass should even consider as flat records. */
+function isFlatCandidate(key: string): boolean {
+  return (
+    !key.startsWith(MATERIAL_PREFIX) &&
+    !key.startsWith(METADATA_PREFIX) &&
+    key !== MIGRATIONS_LEDGER_KEY
+  );
+}
+
+/**
+ * Adopts every legacy flat `<id>` record it can decrypt into the `k/<id>` +
+ * `m/<id>` pair, so it becomes visible to `listMeta()`.
+ *
+ * @remarks
+ * Cheap and side-effect-free when there is nothing to adopt: the MMKV keys are
+ * scanned first and the master key is touched — the only operation that can
+ * raise a biometric/passcode prompt — only when at least one flat candidate
+ * exists. A missing master key is then treated as "nothing to migrate" rather
+ * than an error, since a fresh install has neither a master key nor any flat
+ * records. The pass is idempotent (already-adopted records are `k/`/`m/`
+ * prefixed and therefore excluded) and never destructive: a record is removed
+ * only after both the `k/<id>` and `m/<id>` writes have succeeded, and a
+ * record that fails to decode, decrypt, or carries no `privateKey`/`seed`
+ * material is left untouched and reported in {@link LegacyAdoptionResult.skipped}
+ * instead of aborting the pass.
+ *
+ * @param deps - {@link LegacyAdoptionDeps}.
+ * @returns Which ids were adopted and which were skipped (see
+ *   {@link LegacyAdoptionResult}).
+ *
+ * @example
+ * ```typescript
+ * const { adopted, skipped } = await adoptLegacyRecords({
+ *   storage,
+ *   subtle,
+ *   masterKeyForRead: (auth) => readMasterKey(auth),
+ * });
+ * ```
+ */
+export async function adoptLegacyRecords(deps: LegacyAdoptionDeps): Promise<LegacyAdoptionResult> {
+  const { storage, subtle, masterKeyForRead, authentication } = deps;
+  const candidateIds = storage.getAllKeys().filter(isFlatCandidate);
+  const adopted: string[] = [];
+  const skipped: LegacyAdoptionFailure[] = [];
+  if (candidateIds.length === 0) return { adopted, skipped };
+
+  let masterKey: Uint8Array;
+  try {
+    masterKey = await masterKeyForRead(authentication);
+  } catch (error) {
+    // No master key and nothing has ever been sealed with one — the ordinary
+    // fresh install. Anything else (unlock cancelled, hardware failure, …) is
+    // a real problem the caller should see.
+    if (error instanceof MasterKeyNotFoundError) return { adopted, skipped };
+    throw error;
+  }
+
+  try {
+    for (const id of candidateIds) {
+      const sealed = storage.getString(id);
+      if (sealed === undefined) continue;
+
+      let keyData: KeyData;
+      try {
+        keyData = decode(await openData(subtle, masterKey, sealed));
+      } catch (error) {
+        skipped.push({ id, error });
+        continue;
+      }
+
+      const material = (keyData.privateKey ?? (keyData as { seed?: Uint8Array }).seed) as
+        | Uint8Array
+        | undefined;
+      if (!(material instanceof Uint8Array)) {
+        skipped.push({
+          id,
+          error: new Error(`legacy record "${id}" carries no privateKey/seed material`),
+        });
+        continue;
+      }
+
+      try {
+        const {
+          privateKey: _privateKey,
+          seed: _seed,
+          ...meta
+        } = keyData as unknown as Record<string, unknown>;
+        const metaRecord = { ...meta, id: keyData.id ?? id } as Key;
+        const sealedMaterial = await sealData(subtle, masterKey, base64.encode(material));
+        // Material first: if metadata fails to write, no orphaned `k/<id>`
+        // without its material can exist. The flat record is only removed
+        // once both writes have landed.
+        storage.set(MATERIAL_PREFIX + id, sealedMaterial);
+        storage.set(METADATA_PREFIX + id, serializeKey(metaRecord));
+        storage.remove(id);
+        adopted.push(id);
+      } catch (error) {
+        // Roll back any partial write so a stray `k/`/`m/` entry never
+        // outlives a failed pass; the flat record itself was never removed,
+        // so no data is lost.
+        storage.remove(MATERIAL_PREFIX + id);
+        storage.remove(METADATA_PREFIX + id);
+        skipped.push({ id, error });
+      } finally {
+        clearBuffer(material);
+      }
+    }
+  } finally {
+    clearBuffer(masterKey);
+  }
+
+  return { adopted, skipped };
+}

--- a/keystore/react-native/src/types.ts
+++ b/keystore/react-native/src/types.ts
@@ -26,6 +26,31 @@ export interface ReactKeystoreOptions extends KeyStoreOptions {
 }
 
 /**
+ * The context this package's data migrations run against (see `./migrations`).
+ *
+ * Built by `WithKeyStore` when it registers the module with a provider's
+ * `migrations` extension, and resolved by the runner **lazily** — only when at
+ * least one revision is actually pending — so constructing it must stay cheap
+ * and side-effect-free. Revision `0001` only touches `storage`; revision
+ * `0002` additionally opens and re-seals material, which is why the host
+ * `subtle` and the master-key read are part of the context rather than being
+ * imported concretely by the revision files.
+ */
+export interface KeystoreMigrationContext {
+  /** The MMKV-style store holding this keystore's records. */
+  storage: KeychainStorage;
+  /** Host Subtle implementation used to open/re-seal material. */
+  subtle: SubtleCrypto;
+  /**
+   * Resolves the existing master key for a **read**. Must not create one — a
+   * missing master key is how a fresh install (nothing to migrate) looks.
+   */
+  masterKeyForRead: (options?: AuthenticationOptions) => Promise<Uint8Array>;
+  /** Authentication policy forwarded to {@link KeystoreMigrationContext.masterKeyForRead}. */
+  authentication?: AuthenticationOptions;
+}
+
+/**
  * The material-touching keystore operations that can carry their own
  * authentication prompt wording (via {@link AuthenticationOptions.prompts} /
  * {@link AuthenticationOptions.resolvePrompt}). Mirrors `KeyStoreAPI` in


### PR DESCRIPTION
## Summary

The keystore driver reads a split record layout: `k/<id>` for key material and `m/<id>` for metadata. Two legacy writers produced flat `<id>` records instead: the deprecated `commit()` path and the native passkey AutoFill provider. Those records are invisible to the driver until adopted.

This PR ports the previously ad-hoc adoption pass into a formal, tracked migration: revision `0002-adopt-flat-records` of the `@algorandfoundation/provider-migrations` engine. Adoption now runs once per ledger instead of on every engine start.

## What changed

### Adoption logic

- `storage/legacy.ts` (new): `adoptLegacyRecords` splits each flat `<id>` record into the `k/<id>` + `m/<id>` layout. It reads the master key once per pass, skips undecryptable and no-material records non-destructively, rolls back on partial writes, zeroes plaintext buffers in `finally`, and excludes the migrations ledger key from the candidate scan.
- Legacy `{iv,tag,content}` envelopes decode correctly, covered by a round-trip test.

### Migration revision

- `migrations/0002-adopt-flat-records.ts` (new): runs the adoption pass, reports adopted and skipped counts via `utils.log`, then re-runs the idempotent `0001` passkey-flag pass so flat passkeys picked up by adoption are also flagged.
- The module context widens to `KeystoreMigrationContext` (`storage`, `subtle`, `masterKeyForRead`, `authentication`); revision `0001`, the manifest, and the lazy `context()` registration in `WithKeyStore` are updated accordingly.

### Native writer precondition

- Adds the `passkeys/react-native-autofill` submodule at `1.0.0-canary.23`, the version whose native writers produce the split layout. Because `0002` runs once per ledger, anything still writing flat records after it has run stays invisible to the driver, so the AutoFill update must ship before or together with this migration.

### Plumbing and docs

- `driver.ts` exports `MATERIAL_PREFIX`, `METADATA_PREFIX`, and `serializeKey` so the adoption pass and tests share the record naming.
- New `migrationContext` test fixture; `README.md` documents both revisions and the AutoFill precondition.

## Why now

The AutoFill provider now shares the keystore, so flat records are actively being produced in the wild. With the migrations engine landed (#30), the one-shot adoption can be tracked in the ledger rather than re-scanned ad-hoc on every start, and the AutoFill side has been updated to stop producing flat records going forward.

## Testing

- `keystore/react-native`: 85/85 vitest tests across 11 files, including 7 new `legacy.test.ts` cases (envelope round-trips, skips, rollback) and 6 new `0002` cases (counts, logging, `assertIdempotent` over skipped records).
- `tsc -p tsconfig.build.json` clean; `oxlint` and `oxfmt --check` clean.

## Compatibility

- Adoption is non-destructive: skipped records are left in place and reported, never deleted.
- Revision `0002` is idempotent, so a re-run against an already-adopted store is a no-op.
- No public API changes to `WithKeyStore`; the migrations dependency stays a pure opt-in probe (`import type` only).

## Notes

- Stacked on #30 (`feat/migrations-engine`); the `migrations/` package itself is untouched. Waiting on CI/CD to publish `@algorandfoundation/provider-migrations` before this can go green on a fresh checkout, since the package must be built for the keystore tests to resolve it.
