### PR TITLE
fix: add configurable options for different encryption operations

### DIFF
--- a/keystore/core/README.md
+++ b/keystore/core/README.md
@@ -84,7 +84,23 @@ supply platform-native bindings.
 
 The engine is the single source of the `KeyStoreAPI`. Beyond the core
 sign/verify/generate/derive flow it also provides `encryptWithKey`/
-`decryptWithKey` (host Subtle AES-GCM keyed off a key's public bytes),
+`decryptWithKey`, which resolve the best scheme from the key and the options:
+
+- **Self-encryption** (the default): host Subtle AES-GCM keyed off the key's
+  **private** material, unlocked just-in-time through the driver — never off
+  the public bytes, which anyone could re-derive: HKDF over sealed private
+  bytes on byte-only backends, and on native-`CryptoKey` backends the host key
+  itself for AES-GCM keys or an ECDH/X25519 self-agreement for EC keys.
+- **Peer encryption** (`options.recipientPublicKey` set): an HPKE (RFC 9180)
+  **Auth-mode** seal in the `DHKEM(P-256, HKDF-SHA256)` + `HKDF-SHA256` +
+  `AES-128-GCM` suite, run entirely through the injected host Subtle — a key
+  agreement between this key's private material and the third party's public
+  key, so only the recipient can decrypt and opening also authenticates the
+  sender (whose public key rides in the frame). This requires an ECDH P-256
+  key generated with the `deriveBits` usage; XHD agreements go through
+  `deriveSharedSecret` instead.
+
+It further provides
 `deriveSharedSecret` (the Diffie-Hellman/ECDH negotiation path — routed through
 the XHD shim for HD-derived keys and host ECDH otherwise), and `clear` (when the
 driver supports a bulk clear). When an optional `hooks` collection is supplied,

--- a/keystore/core/src/create.test.ts
+++ b/keystore/core/src/create.test.ts
@@ -23,7 +23,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import { createKeyStore, type KeyStore } from "./create.ts";
 import type { DriverCapabilities, DriverMaterial, KeyStoreDriver } from "./types/driver.ts";
-import type { Key, KeyId } from "./types/core.ts";
+import type { GenerateOptions, Key, KeyId } from "./types/core.ts";
 import type { KeyStoreState } from "./types/extension.ts";
 import {
   type Algo25Binding,
@@ -594,7 +594,7 @@ describe("createKeyStore (byte-only driver)", () => {
     expect(materials.size).toBe(0);
   });
 
-  it("encrypts and decrypts round-trip with a key's public key", async () => {
+  it("encrypts and decrypts round-trip with a key's private material", async () => {
     const id = await keystore.generate({
       type: "ed25519",
       algorithm: "EdDSA",
@@ -604,7 +604,7 @@ describe("createKeyStore (byte-only driver)", () => {
     const plaintext = new TextEncoder().encode("negotiation payload");
     const ciphertext = await keystore.encryptWithKey!(id, plaintext);
     // Version byte + 12-byte IV + AES-GCM output (>= plaintext + 16-byte tag).
-    expect(ciphertext[0]).toBe(1);
+    expect(ciphertext[0]).toBe(2);
     expect(ciphertext.byteLength).toBeGreaterThan(plaintext.byteLength + 12);
     const decrypted = await keystore.decryptWithKey!(id, ciphertext);
     expect(new TextDecoder().decode(decrypted)).toBe("negotiation payload");
@@ -618,10 +618,158 @@ describe("createKeyStore (byte-only driver)", () => {
       keyUsages: ["sign", "verify"],
     });
     const garbage = crypto.getRandomValues(new Uint8Array(64));
-    garbage[0] = 2; // version 2 is unsupported
+    garbage[0] = 4; // version 4 is unsupported
     await expect(keystore.decryptWithKey!(id, garbage)).rejects.toThrow(
       /unsupported ciphertext version/,
     );
+  });
+
+  it("rejects the retired public-key-derived (version 1) ciphertext", async () => {
+    const id = await keystore.generate({
+      type: "ed25519",
+      algorithm: "EdDSA",
+      extractable: false,
+      keyUsages: ["sign", "verify"],
+    });
+    // Version 1 keyed the cipher off the PUBLIC bytes, so anyone holding the
+    // public key could decrypt it — it must be refused, never decrypted.
+    const legacy = crypto.getRandomValues(new Uint8Array(64));
+    legacy[0] = 1;
+    await expect(keystore.decryptWithKey!(id, legacy)).rejects.toThrow(
+      /unsupported ciphertext version: 1/,
+    );
+  });
+
+  it("keeps ciphertext confidential from an attacker holding only the public key", async () => {
+    const id = await keystore.generate({
+      type: "ed25519",
+      algorithm: "EdDSA",
+      extractable: false,
+      keyUsages: ["sign", "verify"],
+    });
+    const plaintext = new TextEncoder().encode("attack at dawn");
+    const ciphertext = await keystore.encryptWithKey!(id, plaintext);
+    const publicKey = store.state.keys.find((k) => k.id === id)!.publicKey!;
+
+    // Replay the audited attack: re-derive the AES key from the PUBLIC bytes
+    // alone — under the retired v1 scheme's parameters and the current v2 ones
+    // alike — and try to open the ciphertext. Every derivation must fail: only
+    // the sealed private material can reproduce the real key.
+    const iv = ciphertext.subarray(1, 13);
+    const payload = ciphertext.subarray(13);
+    for (const info of ["keystore-encrypt-v1", "keystore-encrypt-v2"]) {
+      for (const salt of [new Uint8Array(0), publicKey]) {
+        const base = await host.importKey(
+          "raw",
+          publicKey as unknown as BufferSource,
+          "HKDF",
+          false,
+          ["deriveKey"],
+        );
+        const aes = await host.deriveKey(
+          {
+            name: "HKDF",
+            hash: "SHA-256",
+            salt: salt as unknown as BufferSource,
+            info: new TextEncoder().encode(info),
+          },
+          base,
+          { name: "AES-GCM", length: 256 },
+          false,
+          ["decrypt"],
+        );
+        await expect(
+          host.decrypt(
+            { name: "AES-GCM", iv: iv as unknown as BufferSource },
+            aes,
+            payload as unknown as BufferSource,
+          ),
+        ).rejects.toThrow();
+      }
+    }
+  });
+
+  it("seals to a third-party public key with HPKE so only the recipient can open it", async () => {
+    const ecdhOptions: GenerateOptions = {
+      type: "ecc",
+      algorithm: "ECDH",
+      extractable: false,
+      keyUsages: ["deriveBits", "deriveKey"],
+      params: { namedCurve: "P-256" },
+    };
+    const aliceId = await keystore.generate(ecdhOptions);
+    const bobId = await keystore.generate(ecdhOptions);
+    // The metadata mirror carries the SPKI public bytes — exactly what a peer
+    // would be handed as the recipient key.
+    const bobPublic = store.state.keys.find((k) => k.id === bobId)!.publicKey!;
+
+    const plaintext = new TextEncoder().encode("dear bob");
+    const sealed = await keystore.encryptWithKey!(aliceId, plaintext, {
+      recipientPublicKey: bobPublic,
+    });
+    // Peer layout: [version=3 | suite=1 | senderPub(65) | enc(65) | ct].
+    expect(sealed[0]).toBe(3);
+    expect(sealed[1]).toBe(1);
+    expect(sealed.byteLength).toBeGreaterThan(2 + 65 + 65 + plaintext.byteLength);
+
+    const opened = await keystore.decryptWithKey!(bobId, sealed);
+    expect(new TextDecoder().decode(opened)).toBe("dear bob");
+
+    // Nobody but the addressed recipient can open it — not even the sender.
+    await expect(keystore.decryptWithKey!(aliceId, sealed)).rejects.toThrow();
+  });
+
+  it("authenticates the sender of a peer-sealed ciphertext", async () => {
+    const ecdhOptions: GenerateOptions = {
+      type: "ecc",
+      algorithm: "ECDH",
+      extractable: false,
+      keyUsages: ["deriveBits", "deriveKey"],
+      params: { namedCurve: "P-256" },
+    };
+    const aliceId = await keystore.generate(ecdhOptions);
+    const bobId = await keystore.generate(ecdhOptions);
+    const malloryId = await keystore.generate(ecdhOptions);
+    const bobPublic = store.state.keys.find((k) => k.id === bobId)!.publicKey!;
+
+    const sealed = await keystore.encryptWithKey!(aliceId, message, {
+      recipientPublicKey: bobPublic,
+    });
+
+    // Swap the framed sender for Mallory's public key: HPKE Auth mode binds
+    // the sender's static key into the agreement, so the forgery must fail.
+    const malloryPublic = store.state.keys.find((k) => k.id === malloryId)!.publicKey!;
+    const malloryKey = await host.importKey(
+      "spki",
+      malloryPublic as unknown as BufferSource,
+      { name: "ECDH", namedCurve: "P-256" },
+      true,
+      [],
+    );
+    const malloryPoint = new Uint8Array(await host.exportKey("raw", malloryKey));
+    const forged = Uint8Array.from(sealed);
+    forged.set(malloryPoint, 2);
+    await expect(keystore.decryptWithKey!(bobId, forged)).rejects.toThrow();
+  });
+
+  it("refuses peer encryption for a key that was not generated for derivation", async () => {
+    const signingId = await keystore.generate({
+      type: "ed25519",
+      algorithm: "EdDSA",
+      extractable: false,
+      keyUsages: ["sign", "verify"],
+    });
+    const recipientId = await keystore.generate({
+      type: "ecc",
+      algorithm: "ECDH",
+      extractable: false,
+      keyUsages: ["deriveBits", "deriveKey"],
+      params: { namedCurve: "P-256" },
+    });
+    const recipientPublicKey = store.state.keys.find((k) => k.id === recipientId)!.publicKey!;
+    await expect(
+      keystore.encryptWithKey!(signingId, message, { recipientPublicKey }),
+    ).rejects.toThrow(/ECDH P-256/);
   });
 
   it("never records generation secrets in (plaintext) metadata", async () => {

--- a/keystore/core/src/create.ts
+++ b/keystore/core/src/create.ts
@@ -24,13 +24,14 @@ import type { HookCollection } from "before-after-hook";
 import { DEFAULT_HOST_ALGORITHMS } from "./constants.ts";
 import { createDefaultShims } from "./defaults.ts";
 import { InvalidKeyDataError, InvalidKeyFormatError, KeyNotFoundError } from "./errors.ts";
+import { HPKE_P256_POINT_LENGTH, hpkeOpenAuth, hpkeSealAuth } from "./hpke.ts";
 import {
   BIP32DerivationType,
   consumeKeyMaterial,
   createKeyHandle,
   type SubtleShim,
 } from "./shims/index.ts";
-import type { KeyStoreAPI } from "./types/backend.ts";
+import type { KeyDecryptionOptions, KeyEncryptionOptions, KeyStoreAPI } from "./types/backend.ts";
 import type {
   DeriveOptions,
   ExportOptions,
@@ -41,7 +42,7 @@ import type {
   KeyId,
   KeyOptions,
 } from "./types/core.ts";
-import type { KeyStoreDriver } from "./types/driver.ts";
+import type { DriverMaterial, KeyStoreDriver } from "./types/driver.ts";
 import type { KeyStoreCapability, KeyStoreState } from "./types/extension.ts";
 
 /**
@@ -235,32 +236,205 @@ function parsePath(path: string): number[] {
  */
 const PASSPHRASE_SECRET_SUFFIX = ".passphrase";
 
-/** Version byte prefixing {@link KeyStoreAPI.encryptWithKey} ciphertext. */
-const ENCRYPT_VERSION = 1;
+/**
+ * Version byte prefixing {@link KeyStoreAPI.encryptWithKey} ciphertext.
+ *
+ * Version 1 was the retired scheme that keyed the cipher off the key's
+ * **public** bytes (mirroring the original backend's hash-of-public-key
+ * secretbox): anyone holding the public key could re-derive its symmetric key,
+ * so version-1 ciphertexts are rejected rather than decrypted.
+ */
+const ENCRYPT_VERSION = 2;
 /** HKDF `info` binding the derived AES key to this keystore's encrypt scheme. */
-const ENCRYPT_INFO = new TextEncoder().encode("keystore-encrypt-v1");
+const ENCRYPT_INFO = new TextEncoder().encode("keystore-encrypt-v2");
 
 /**
- * Derives a deterministic AES-GCM key from a key's **public** bytes via the host
- * Subtle (HKDF over the public key). Because the derivation depends only on the
- * public key, `encryptWithKey`/`decryptWithKey` need no private-material unlock —
- * exactly like the original backend, which keyed a symmetric cipher off a hash
- * of the public key. Here it is standardized on Subtle HKDF + AES-GCM.
+ * Version byte prefixing **peer** (recipient-addressed) `encryptWithKey`
+ * ciphertext: an HPKE (RFC 9180) Auth-mode seal between this key's private
+ * material and the recipient's public key. Self-encrypted payloads keep
+ * {@link ENCRYPT_VERSION}; the two framings coexist and `decryptWithKey`
+ * dispatches on the byte.
  */
-async function deriveAesKeyFromPublic(
+const ENCRYPT_VERSION_PEER = 3;
+/**
+ * Suite byte inside the peer framing. `1` is the only suite so far:
+ * `DHKEM(P-256, HKDF-SHA256)` + `HKDF-SHA256` + `AES-128-GCM`.
+ */
+const ENCRYPT_PEER_SUITE = 1;
+/** HPKE `info` binding peer ciphertexts to this keystore's encrypt scheme. */
+const ENCRYPT_PEER_INFO = new TextEncoder().encode("keystore-encrypt-v3");
+/**
+ * Peer framing: `[version(1) | suite(1) | senderPub(65) | enc(65) | ct]` — the
+ * header is everything before the AEAD ciphertext.
+ */
+const ENCRYPT_PEER_HEADER_LENGTH = 2 + HPKE_P256_POINT_LENGTH * 2;
+
+/**
+ * Derives an AES-GCM key from a key's **private** bytes via the host Subtle
+ * (HKDF-SHA-256 over the sealed private material, salted with the public key so
+ * the derived key is bound to the pair). The private bytes are only ever
+ * available inside {@link KeyStoreDriver.use}, so encrypting and decrypting
+ * require the same unlock as any other material-touching operation — this is
+ * what gives `encryptWithKey`/`decryptWithKey` confidentiality against anyone
+ * who merely knows the public key.
+ */
+async function deriveAesKeyFromPrivate(
   host: SubtleCrypto,
-  publicKey: Uint8Array,
+  privateBytes: Uint8Array,
+  publicKey: Uint8Array | undefined,
 ): Promise<CryptoKey> {
-  const base = await host.importKey("raw", publicKey as unknown as BufferSource, "HKDF", false, [
+  const base = await host.importKey("raw", privateBytes as unknown as BufferSource, "HKDF", false, [
     "deriveKey",
   ]);
   return host.deriveKey(
-    { name: "HKDF", hash: "SHA-256", salt: new Uint8Array(0), info: ENCRYPT_INFO },
+    {
+      name: "HKDF",
+      hash: "SHA-256",
+      salt: (publicKey ?? new Uint8Array(0)) as unknown as BufferSource,
+      info: ENCRYPT_INFO,
+    },
     base,
     { name: "AES-GCM", length: 256 },
     false,
     ["encrypt", "decrypt"],
   );
+}
+
+/**
+ * Resolves the AES-GCM key that seals {@link KeyStoreAPI.encryptWithKey}
+ * ciphertext from whatever material the driver unsealed:
+ *
+ * - `bytes` — HKDF-SHA-256 over the sealed private bytes
+ *   ({@link deriveAesKeyFromPrivate}), the byte-only-backend scheme.
+ * - a native `AES-GCM` {@link CryptoKey} — the stored key itself, handed
+ *   straight to the host so the material never surfaces as bytes.
+ * - a native `ECDH`/`X25519` {@link CryptoKey} — a **self-agreement** (the
+ *   private key against its own public key), a secret only the private-key
+ *   holder can compute, folded through the same HKDF. With a `deriveKey`-only
+ *   key the agreement stays entirely inside the host.
+ *
+ * The source is a fixed property of how the key is persisted, so encrypt and
+ * decrypt always resolve the same AES key for a given id. Any other native key
+ * (a signature-only Ed25519/ECDSA `CryptoKey`, whose WebCrypto usages permit
+ * neither encryption nor key agreement) throws — no secret path to an
+ * encryption key exists for it.
+ */
+async function aesKeyFromMaterial(
+  host: SubtleCrypto,
+  material: DriverMaterial,
+  publicKeyBytes: Uint8Array | undefined,
+  id: KeyId,
+): Promise<CryptoKey> {
+  if (material.kind === "bytes") {
+    return deriveAesKeyFromPrivate(host, material.bytes, publicKeyBytes);
+  }
+  const { privateKey, publicKey } = material;
+  const name = privateKey.algorithm.name;
+  // A native AES-GCM key encrypts directly; nothing to derive.
+  if (name === "AES-GCM") return privateKey;
+  if ((name === "ECDH" || name === "X25519") && publicKey) {
+    const agreement = { name, public: publicKey } as EcdhKeyDeriveParams;
+    if (privateKey.usages.includes("deriveBits")) {
+      const shared = new Uint8Array(await host.deriveBits(agreement, privateKey, 256));
+      try {
+        return await deriveAesKeyFromPrivate(host, shared, publicKeyBytes);
+      } finally {
+        shared.fill(0);
+      }
+    }
+    if (privateKey.usages.includes("deriveKey")) {
+      // `deriveKey`-only key: agree directly into an AES-GCM key so the shared
+      // secret never exists as bytes in JS.
+      return host.deriveKey(agreement, privateKey, { name: "AES-GCM", length: 256 }, false, [
+        "encrypt",
+        "decrypt",
+      ]);
+    }
+  }
+  throw new InvalidKeyDataError(
+    `key ${id} holds a non-extractable ${name} CryptoKey whose usages permit neither encryption nor key agreement`,
+  );
+}
+
+/**
+ * Normalizes an EC public key to the uncompressed P-256 point the HPKE peer
+ * scheme frames and agrees against: a 65-byte point passes through, anything
+ * else is treated as an SPKI document (the shape byte-backed EC records mirror
+ * into {@link Key.publicKey}) and re-exported raw.
+ */
+async function toRawP256Point(host: SubtleCrypto, publicKey: Uint8Array): Promise<Uint8Array> {
+  if (publicKey.byteLength === HPKE_P256_POINT_LENGTH && publicKey[0] === 4) {
+    return publicKey;
+  }
+  const imported = await host.importKey(
+    "spki",
+    bs(publicKey),
+    { name: "ECDH", namedCurve: "P-256" },
+    true,
+    [],
+  );
+  return new Uint8Array(await host.exportKey("raw", imported));
+}
+
+/**
+ * Resolves a key's material into the ECDH pair the HPKE peer scheme needs — a
+ * `deriveBits`-capable P-256 private `CryptoKey` plus the matching
+ * uncompressed public point:
+ *
+ * - a native `ECDH` `CryptoKey` is used as-is (its public half re-exported
+ *   raw), provided its usages include `deriveBits` — HPKE concatenates raw DH
+ *   outputs, which `deriveKey` alone cannot produce;
+ * - byte-backed `ECDH` material is re-imported from its sealed PKCS#8 document
+ *   just-in-time, with the public point taken from the metadata mirror.
+ *
+ * Anything else — signing keys, XHD/HD-derived keys, non-P-256 curves —
+ * throws: peer encryption deliberately requires a key generated for
+ * derivation (`keyUsages: ["deriveBits", ...]`). XHD agreements go through
+ * `deriveSharedSecret` instead.
+ */
+async function resolveEcdhPair(
+  host: SubtleCrypto,
+  material: DriverMaterial,
+  key: Key,
+  id: KeyId,
+): Promise<{ privateKey: CryptoKey; publicKey: Uint8Array }> {
+  if (material.kind === "cryptokey") {
+    const name = material.privateKey.algorithm.name;
+    if (name !== "ECDH") {
+      throw new InvalidKeyDataError(
+        `key ${id} is a ${name} key; peer encryption requires an ECDH P-256 key generated for derivation (use deriveSharedSecret for XHD keys, or generate a dedicated ECDH key)`,
+      );
+    }
+    if (!material.privateKey.usages.includes("deriveBits")) {
+      throw new InvalidKeyDataError(
+        `key ${id} lacks the "deriveBits" usage peer encryption requires; generate the key with keyUsages ["deriveBits"]`,
+      );
+    }
+    if (!material.publicKey) {
+      throw new InvalidKeyDataError(`key ${id} has no public key to run a key agreement with`);
+    }
+    return {
+      privateKey: material.privateKey,
+      publicKey: new Uint8Array(await host.exportKey("raw", material.publicKey)),
+    };
+  }
+  const namedCurve = (key.metadata?.namedCurve as string | undefined) ?? "P-256";
+  if (key.algorithm !== "ECDH" || namedCurve !== "P-256") {
+    throw new InvalidKeyDataError(
+      `key ${id} (${key.algorithm}) is not an ECDH P-256 key; peer encryption requires one generated for derivation (use deriveSharedSecret for XHD keys, or generate a dedicated ECDH key)`,
+    );
+  }
+  if (!key.publicKey) {
+    throw new InvalidKeyDataError(`key ${id} has no public key to run a key agreement with`);
+  }
+  const privateKey = await host.importKey(
+    "pkcs8",
+    bs(material.bytes),
+    { name: "ECDH", namedCurve },
+    false,
+    ["deriveBits"],
+  );
+  return { privateKey, publicKey: await toRawP256Point(host, key.publicKey) };
 }
 
 /**
@@ -809,7 +983,12 @@ export function createKeyStore<Ctx = unknown>(options: CreateKeyStoreOptions<Ctx
       const result = (await host.generateKey(algorithm, false, options.keyUsages)) as
         | CryptoKey
         | CryptoKeyPair;
+      // Public halves are always extractable: mirror the SPKI bytes into the
+      // metadata (like the byte branch below) so a peer can be handed this
+      // key's public key, e.g. as an encryptWithKey recipient.
+      let publicKey: Uint8Array | undefined;
       if ("privateKey" in result) {
+        publicKey = new Uint8Array(await host.exportKey("spki", result.publicKey));
         await driver.put(
           id,
           { kind: "cryptokey", privateKey: result.privateKey, publicKey: result.publicKey },
@@ -824,7 +1003,13 @@ export function createKeyStore<Ctx = unknown>(options: CreateKeyStoreOptions<Ctx
         algorithm: options.algorithm,
         extractable: false,
         keyUsages: options.keyUsages,
-        metadata: { storage: "cryptokey", signAlgorithm, ...publicParams(options.params) },
+        publicKey,
+        metadata: {
+          storage: "cryptokey",
+          signAlgorithm,
+          spki: publicKey !== undefined,
+          ...publicParams(options.params),
+        },
         version: 1,
       });
       return id;
@@ -1293,22 +1478,52 @@ export function createKeyStore<Ctx = unknown>(options: CreateKeyStoreOptions<Ctx
     async encryptWithKey(
       id: KeyId,
       data: Uint8Array,
-      _algorithm?: string,
-      _ctx?: Ctx,
+      options?: KeyEncryptionOptions,
+      ctx?: Ctx,
     ): Promise<Uint8Array> {
       await ready;
       const key = await loadMetadata(id);
-      if (!key.publicKey) {
-        throw new InvalidKeyDataError(`key ${id} has no public key to encrypt with`);
-      }
       setStatus("encrypting");
       try {
-        const aes = await deriveAesKeyFromPublic(host, key.publicKey);
+        const recipient = options?.recipientPublicKey;
+        if (recipient) {
+          // Peer path: seal to the recipient with HPKE Auth mode. The static
+          // ECDH pair is unlocked just-in-time; only the CryptoKey handle
+          // survives the callback.
+          const recipientPublicKey = await toRawP256Point(host, recipient);
+          const sender = await driver.use(id, ctx, (m) => resolveEcdhPair(host, m, key, id));
+          const { enc, ciphertext } = await hpkeSealAuth(host, {
+            recipientPublicKey,
+            senderPrivateKey: sender.privateKey,
+            senderPublicKey: sender.publicKey,
+            info: ENCRYPT_PEER_INFO,
+            aad: new Uint8Array(0),
+            plaintext: data,
+          });
+          // Peer layout: [version(1) | suite(1) | senderPub(65) | enc(65) | ct].
+          // The sender's public point rides along so the recipient's
+          // decryptWithKey is self-contained — it both keys the agreement and
+          // is authenticated by it (a swapped sender fails to open).
+          const out = new Uint8Array(ENCRYPT_PEER_HEADER_LENGTH + ciphertext.byteLength);
+          out[0] = ENCRYPT_VERSION_PEER;
+          out[1] = ENCRYPT_PEER_SUITE;
+          out.set(sender.publicKey, 2);
+          out.set(enc, 2 + HPKE_P256_POINT_LENGTH);
+          out.set(ciphertext, ENCRYPT_PEER_HEADER_LENGTH);
+          return out;
+        }
+        // Self path: unlock the material just-in-time and resolve the AES key
+        // from it — HKDF over private bytes, or the native host key/agreement
+        // when the driver holds a CryptoKey. The AES handle survives the
+        // callback; raw bytes never do.
+        const aes = await driver.use(id, ctx, (m) =>
+          aesKeyFromMaterial(host, m, key.publicKey, id),
+        );
         const iv = crypto.getRandomValues(new Uint8Array(12));
         const ciphertext = new Uint8Array(
           await host.encrypt({ name: "AES-GCM", iv: bs(iv) }, aes, bs(data)),
         );
-        // Layout: [version(1) | iv(12) | ciphertext].
+        // Self layout: [version(1) | iv(12) | ciphertext].
         const out = new Uint8Array(1 + iv.byteLength + ciphertext.byteLength);
         out[0] = ENCRYPT_VERSION;
         out.set(iv, 1);
@@ -1322,23 +1537,48 @@ export function createKeyStore<Ctx = unknown>(options: CreateKeyStoreOptions<Ctx
     async decryptWithKey(
       id: KeyId,
       data: Uint8Array,
-      _algorithm?: string,
-      _ctx?: Ctx,
+      _options?: KeyDecryptionOptions,
+      ctx?: Ctx,
     ): Promise<Uint8Array> {
       await ready;
       const key = await loadMetadata(id);
-      if (!key.publicKey) {
-        throw new InvalidKeyDataError(`key ${id} has no public key to decrypt with`);
-      }
       setStatus("decrypting");
       try {
         const version = data[0];
+        if (version === ENCRYPT_VERSION_PEER) {
+          // Peer path: open an HPKE Auth-mode seal addressed to this key. The
+          // sender's public point comes from the frame and is authenticated by
+          // the agreement itself.
+          if (data[1] !== ENCRYPT_PEER_SUITE) {
+            throw new InvalidKeyFormatError(
+              `unsupported peer-encryption suite: ${String(data[1])}`,
+            );
+          }
+          if (data.byteLength <= ENCRYPT_PEER_HEADER_LENGTH) {
+            throw new InvalidKeyFormatError("truncated peer-encrypted ciphertext");
+          }
+          const senderPublicKey = data.subarray(2, 2 + HPKE_P256_POINT_LENGTH);
+          const enc = data.subarray(2 + HPKE_P256_POINT_LENGTH, ENCRYPT_PEER_HEADER_LENGTH);
+          const ciphertext = data.subarray(ENCRYPT_PEER_HEADER_LENGTH);
+          const recipient = await driver.use(id, ctx, (m) => resolveEcdhPair(host, m, key, id));
+          return await hpkeOpenAuth(host, {
+            enc,
+            recipientPrivateKey: recipient.privateKey,
+            recipientPublicKey: recipient.publicKey,
+            senderPublicKey,
+            info: ENCRYPT_PEER_INFO,
+            aad: new Uint8Array(0),
+            ciphertext,
+          });
+        }
         if (version !== ENCRYPT_VERSION) {
           throw new InvalidKeyFormatError(`unsupported ciphertext version: ${String(version)}`);
         }
         const iv = data.subarray(1, 13);
         const ciphertext = data.subarray(13);
-        const aes = await deriveAesKeyFromPublic(host, key.publicKey as Uint8Array);
+        const aes = await driver.use(id, ctx, (m) =>
+          aesKeyFromMaterial(host, m, key.publicKey, id),
+        );
         return new Uint8Array(
           await host.decrypt({ name: "AES-GCM", iv: bs(iv) }, aes, bs(ciphertext)),
         );

--- a/keystore/core/src/hpke.test.ts
+++ b/keystore/core/src/hpke.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+
+import { type HpkeEphemeralKey, hpkeOpenAuth, hpkeSealAuth } from "./hpke.ts";
+
+const subtle = globalThis.crypto.subtle;
+
+function hexToBytes(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i += 1) {
+    out[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function base64Url(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/**
+ * Imports a raw P-256 private scalar as an ECDH `CryptoKey` via JWK, taking
+ * the public coordinates from the matching uncompressed point.
+ */
+async function importPrivate(scalarHex: string, pointHex: string): Promise<CryptoKey> {
+  const point = hexToBytes(pointHex);
+  return subtle.importKey(
+    "jwk",
+    {
+      kty: "EC",
+      crv: "P-256",
+      d: base64Url(hexToBytes(scalarHex)),
+      x: base64Url(point.subarray(1, 33)),
+      y: base64Url(point.subarray(33, 65)),
+    },
+    { name: "ECDH", namedCurve: "P-256" },
+    false,
+    ["deriveBits"],
+  ) as Promise<CryptoKey>;
+}
+
+/**
+ * RFC 9180 Appendix A.3.3 — DHKEM(P-256, HKDF-SHA256), HKDF-SHA256,
+ * AES-128-GCM, Auth mode setup information and the sequence-0 encryption.
+ */
+const vector = {
+  info: "4f6465206f6e2061204772656369616e2055726e",
+  pkEm: "042224f3ea800f7ec55c03f29fc9865f6ee27004f818fcbdc6dc68932c1e52e15b79e264a98f2c535ef06745f3d308624414153b22c7332bc1e691cb4af4d53454",
+  skEm: "6b8de0873aed0c1b2d09b8c7ed54cbf24fdf1dfc7a47fa501f918810642d7b91",
+  pkRm: "04423e363e1cd54ce7b7573110ac121399acbc9ed815fae03b72ffbd4c18b01836835c5a09513f28fc971b7266cfde2e96afe84bb0f266920e82c4f53b36e1a78d",
+  skRm: "d929ab4be2e59f6954d6bedd93e638f02d4046cef21115b00cdda2acb2a4440e",
+  pkSm: "04a817a0902bf28e036d66add5d544cc3a0457eab150f104285df1e293b5c10eef8651213e43d9cd9086c80b309df22cf37609f58c1127f7607e85f210b2804f73",
+  skSm: "1120ac99fb1fccc1e8230502d245719d1b217fe20505c7648795139d177f0de9",
+  pt: "4265617574792069732074727574682c20747275746820626561757479",
+  aad0: "436f756e742d30",
+  ct0: "82ffc8c44760db691a07c5627e5fc2c08e7a86979ee79b494a17cc3405446ac2bdb8f265db4a099ed3289ffe19",
+};
+
+async function ephemeralFromVector(): Promise<HpkeEphemeralKey> {
+  return {
+    privateKey: await importPrivate(vector.skEm, vector.pkEm),
+    publicKey: hexToBytes(vector.pkEm),
+  };
+}
+
+describe("hpke (RFC 9180 A.3.3 — Auth mode, DHKEM(P-256), HKDF-SHA256, AES-128-GCM)", () => {
+  it("seals to the exact RFC ciphertext with the vector's ephemeral key", async () => {
+    const { enc, ciphertext } = await hpkeSealAuth(subtle, {
+      recipientPublicKey: hexToBytes(vector.pkRm),
+      senderPrivateKey: await importPrivate(vector.skSm, vector.pkSm),
+      senderPublicKey: hexToBytes(vector.pkSm),
+      info: hexToBytes(vector.info),
+      aad: hexToBytes(vector.aad0),
+      plaintext: hexToBytes(vector.pt),
+      ephemeralKey: await ephemeralFromVector(),
+    });
+    expect(bytesToHex(enc)).toBe(vector.pkEm);
+    expect(bytesToHex(ciphertext)).toBe(vector.ct0);
+  });
+
+  it("opens the RFC ciphertext with the recipient private key", async () => {
+    const plaintext = await hpkeOpenAuth(subtle, {
+      enc: hexToBytes(vector.pkEm),
+      recipientPrivateKey: await importPrivate(vector.skRm, vector.pkRm),
+      recipientPublicKey: hexToBytes(vector.pkRm),
+      senderPublicKey: hexToBytes(vector.pkSm),
+      info: hexToBytes(vector.info),
+      aad: hexToBytes(vector.aad0),
+      ciphertext: hexToBytes(vector.ct0),
+    });
+    expect(bytesToHex(plaintext)).toBe(vector.pt);
+  });
+
+  it("round-trips with a fresh ephemeral key and rejects a wrong sender claim", async () => {
+    const recipientPrivateKey = await importPrivate(vector.skRm, vector.pkRm);
+    const plaintext = new TextEncoder().encode("fresh ephemeral round-trip");
+    const { enc, ciphertext } = await hpkeSealAuth(subtle, {
+      recipientPublicKey: hexToBytes(vector.pkRm),
+      senderPrivateKey: await importPrivate(vector.skSm, vector.pkSm),
+      senderPublicKey: hexToBytes(vector.pkSm),
+      info: hexToBytes(vector.info),
+      aad: new Uint8Array(0),
+      plaintext,
+    });
+    // A fresh ephemeral key must never repeat the vector's encapsulation.
+    expect(bytesToHex(enc)).not.toBe(vector.pkEm);
+    const opened = await hpkeOpenAuth(subtle, {
+      enc,
+      recipientPrivateKey,
+      recipientPublicKey: hexToBytes(vector.pkRm),
+      senderPublicKey: hexToBytes(vector.pkSm),
+      info: hexToBytes(vector.info),
+      aad: new Uint8Array(0),
+      ciphertext,
+    });
+    expect(new TextDecoder().decode(opened)).toBe("fresh ephemeral round-trip");
+
+    // Claiming a different sender (here: the ephemeral point) must fail auth.
+    await expect(
+      hpkeOpenAuth(subtle, {
+        enc,
+        recipientPrivateKey,
+        recipientPublicKey: hexToBytes(vector.pkRm),
+        senderPublicKey: hexToBytes(vector.pkEm),
+        info: hexToBytes(vector.info),
+        aad: new Uint8Array(0),
+        ciphertext,
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/keystore/core/src/hpke.ts
+++ b/keystore/core/src/hpke.ts
@@ -1,0 +1,318 @@
+/**
+ * A minimal RFC 9180 (Hybrid Public Key Encryption) implementation covering
+ * exactly what {@link import("./create.ts").KeyStore.encryptWithKey} needs:
+ * **Auth mode** (`mode_auth`, `0x02`), **single-shot** seal/open, in the fixed
+ * ciphersuite `DHKEM(P-256, HKDF-SHA256)` (`0x0010`) + `HKDF-SHA256` (`0x0001`)
+ * + `AES-128-GCM` (`0x0001`).
+ *
+ * Every primitive runs through the **injected host {@link SubtleCrypto}**
+ * (ECDH `deriveBits`, `HMAC` sign for HKDF-Extract/Expand, `AES-GCM`), never
+ * through `globalThis.crypto`, so the module honours the keystore's
+ * injected-host seam — the reason an off-the-shelf HPKE package (which
+ * discovers the runtime WebCrypto itself) is not used here. Conformance is
+ * pinned by the RFC 9180 Appendix A.3.3 test vectors in `hpke.test.ts`.
+ */
+
+/** Casts a `Uint8Array` to the DOM `BufferSource` the Subtle typings expect. */
+function bs(view: Uint8Array): BufferSource {
+  return view as unknown as BufferSource;
+}
+
+/** Concatenates byte arrays. */
+function concat(...parts: Uint8Array[]): Uint8Array {
+  const out = new Uint8Array(parts.reduce((n, p) => n + p.byteLength, 0));
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.byteLength;
+  }
+  return out;
+}
+
+const utf8 = new TextEncoder();
+const EMPTY = new Uint8Array(0);
+
+/** `suite_id` = "HPKE" || kem_id (0x0010) || kdf_id (0x0001) || aead_id (0x0001). */
+const SUITE_ID = concat(utf8.encode("HPKE"), new Uint8Array([0, 0x10, 0, 1, 0, 1]));
+/** KEM `suite_id` = "KEM" || kem_id (0x0010). */
+const KEM_SUITE_ID = concat(utf8.encode("KEM"), new Uint8Array([0, 0x10]));
+/** RFC 9180 `mode_auth`. */
+const MODE_AUTH = 0x02;
+/** AES-128-GCM key length (`Nk`). */
+const NK = 16;
+/** AES-GCM nonce length (`Nn`). */
+const NN = 12;
+/** DHKEM(P-256) shared-secret length (`Nsecret`) and SHA-256 output length. */
+const NSECRET = 32;
+/** Uncompressed P-256 point length (`Npk` = `Nenc`). */
+export const HPKE_P256_POINT_LENGTH = 65;
+
+/** The WebCrypto algorithm of every asymmetric key this module touches. */
+const P256: EcKeyImportParams = { name: "ECDH", namedCurve: "P-256" };
+
+/**
+ * `HMAC-SHA-256(key, data)` through the host Subtle — the primitive both
+ * HKDF-Extract and HKDF-Expand reduce to. An empty `key` is replaced by
+ * `HashLen` zero bytes exactly as RFC 5869 defines for an absent salt (and as
+ * WebCrypto's own HKDF does internally).
+ */
+async function hmacSha256(
+  host: SubtleCrypto,
+  key: Uint8Array,
+  data: Uint8Array,
+): Promise<Uint8Array> {
+  const hmacKey = await host.importKey(
+    "raw",
+    bs(key.byteLength === 0 ? new Uint8Array(NSECRET) : key),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  return new Uint8Array(await host.sign("HMAC", hmacKey, bs(data)));
+}
+
+/** RFC 9180 `LabeledExtract(salt, label, ikm)` = `Extract(salt, "HPKE-v1" || suite_id || label || ikm)`. */
+async function labeledExtract(
+  host: SubtleCrypto,
+  suiteId: Uint8Array,
+  salt: Uint8Array,
+  label: string,
+  ikm: Uint8Array,
+): Promise<Uint8Array> {
+  return hmacSha256(host, salt, concat(utf8.encode("HPKE-v1"), suiteId, utf8.encode(label), ikm));
+}
+
+/**
+ * RFC 9180 `LabeledExpand(prk, label, info, L)` for `L <= HashLen`, which is
+ * all this suite ever needs — a single HKDF-Expand block:
+ * `T(1) = HMAC(prk, labeled_info || 0x01)`.
+ */
+async function labeledExpand(
+  host: SubtleCrypto,
+  suiteId: Uint8Array,
+  prk: Uint8Array,
+  label: string,
+  info: Uint8Array,
+  length: number,
+): Promise<Uint8Array> {
+  const labeledInfo = concat(
+    new Uint8Array([length >> 8, length & 0xff]),
+    utf8.encode("HPKE-v1"),
+    suiteId,
+    utf8.encode(label),
+    info,
+    new Uint8Array([1]),
+  );
+  const block = await hmacSha256(host, prk, labeledInfo);
+  return block.subarray(0, length);
+}
+
+/** Imports an uncompressed P-256 point as an ECDH public `CryptoKey`. */
+async function importPublic(host: SubtleCrypto, point: Uint8Array): Promise<CryptoKey> {
+  return host.importKey("raw", bs(point), P256, false, []);
+}
+
+/** Raw ECDH: the x-coordinate of `[privateKey]publicKey`, 32 bytes for P-256. */
+async function dh(
+  host: SubtleCrypto,
+  privateKey: CryptoKey,
+  publicKey: CryptoKey,
+): Promise<Uint8Array> {
+  return new Uint8Array(
+    await host.deriveBits({ name: "ECDH", public: publicKey }, privateKey, 256),
+  );
+}
+
+/**
+ * An ephemeral KEM key pair. Normally minted per seal inside
+ * {@link hpkeSealAuth}; injectable only so the RFC 9180 test vectors (which
+ * fix `skEm`) can drive the exact code path.
+ */
+export interface HpkeEphemeralKey {
+  /** The ephemeral ECDH private key (`deriveBits`-capable). */
+  privateKey: CryptoKey;
+  /** The matching uncompressed public point (`enc`). */
+  publicKey: Uint8Array;
+}
+
+/** Generates a fresh {@link HpkeEphemeralKey} through the host. */
+async function generateEphemeral(host: SubtleCrypto): Promise<HpkeEphemeralKey> {
+  const pair = (await host.generateKey(P256, false, ["deriveBits"])) as CryptoKeyPair;
+  return {
+    privateKey: pair.privateKey,
+    publicKey: new Uint8Array(await host.exportKey("raw", pair.publicKey)),
+  };
+}
+
+/**
+ * RFC 9180 `AuthEncap`: combines an ephemeral-recipient and a static
+ * sender-recipient ECDH into the KEM shared secret, returning it with the
+ * encapsulated ephemeral public key (`enc`).
+ */
+async function authEncap(
+  host: SubtleCrypto,
+  recipientPublicKey: Uint8Array,
+  senderPrivateKey: CryptoKey,
+  senderPublicKey: Uint8Array,
+  ephemeralKey?: HpkeEphemeralKey,
+): Promise<{ sharedSecret: Uint8Array; enc: Uint8Array }> {
+  const pkR = await importPublic(host, recipientPublicKey);
+  const ephemeral = ephemeralKey ?? (await generateEphemeral(host));
+  const dhBytes = concat(
+    await dh(host, ephemeral.privateKey, pkR),
+    await dh(host, senderPrivateKey, pkR),
+  );
+  const kemContext = concat(ephemeral.publicKey, recipientPublicKey, senderPublicKey);
+  const sharedSecret = await extractAndExpand(host, dhBytes, kemContext);
+  dhBytes.fill(0);
+  return { sharedSecret, enc: ephemeral.publicKey };
+}
+
+/** RFC 9180 `AuthDecap`: the recipient-side mirror of {@link authEncap}. */
+async function authDecap(
+  host: SubtleCrypto,
+  enc: Uint8Array,
+  recipientPrivateKey: CryptoKey,
+  recipientPublicKey: Uint8Array,
+  senderPublicKey: Uint8Array,
+): Promise<Uint8Array> {
+  const pkE = await importPublic(host, enc);
+  const pkS = await importPublic(host, senderPublicKey);
+  const dhBytes = concat(
+    await dh(host, recipientPrivateKey, pkE),
+    await dh(host, recipientPrivateKey, pkS),
+  );
+  const kemContext = concat(enc, recipientPublicKey, senderPublicKey);
+  const sharedSecret = await extractAndExpand(host, dhBytes, kemContext);
+  dhBytes.fill(0);
+  return sharedSecret;
+}
+
+/** RFC 9180 `ExtractAndExpand` for the KEM: `dh` -> `shared_secret`. */
+async function extractAndExpand(
+  host: SubtleCrypto,
+  dhBytes: Uint8Array,
+  kemContext: Uint8Array,
+): Promise<Uint8Array> {
+  const eaePrk = await labeledExtract(host, KEM_SUITE_ID, EMPTY, "eae_prk", dhBytes);
+  return labeledExpand(host, KEM_SUITE_ID, eaePrk, "shared_secret", kemContext, NSECRET);
+}
+
+/**
+ * RFC 9180 `KeySchedule` for `mode_auth` without a PSK, reduced to the
+ * single-shot needs: the AEAD key (imported straight into a non-extractable
+ * `AES-GCM` `CryptoKey`) and `base_nonce` (the sequence-0 nonce).
+ */
+async function keySchedule(
+  host: SubtleCrypto,
+  sharedSecret: Uint8Array,
+  info: Uint8Array,
+  usage: "encrypt" | "decrypt",
+): Promise<{ aeadKey: CryptoKey; baseNonce: Uint8Array }> {
+  const pskIdHash = await labeledExtract(host, SUITE_ID, EMPTY, "psk_id_hash", EMPTY);
+  const infoHash = await labeledExtract(host, SUITE_ID, EMPTY, "info_hash", info);
+  const context = concat(new Uint8Array([MODE_AUTH]), pskIdHash, infoHash);
+  const secret = await labeledExtract(host, SUITE_ID, sharedSecret, "secret", EMPTY);
+  const keyBytes = await labeledExpand(host, SUITE_ID, secret, "key", context, NK);
+  const baseNonce = await labeledExpand(host, SUITE_ID, secret, "base_nonce", context, NN);
+  secret.fill(0);
+  const aeadKey = await host.importKey("raw", bs(keyBytes), { name: "AES-GCM" }, false, [usage]);
+  keyBytes.fill(0);
+  return { aeadKey, baseNonce };
+}
+
+/** Inputs for {@link hpkeSealAuth}. */
+export interface HpkeSealOptions {
+  /** The recipient's uncompressed P-256 public point (`pkRm`). */
+  recipientPublicKey: Uint8Array;
+  /** The sender's static ECDH private key (`skS`), `deriveBits`-capable. */
+  senderPrivateKey: CryptoKey;
+  /** The sender's uncompressed P-256 public point (`pkSm`). */
+  senderPublicKey: Uint8Array;
+  /** Application-supplied `info` binding the derived keys to their purpose. */
+  info: Uint8Array;
+  /** Additional authenticated data for the AEAD. */
+  aad: Uint8Array;
+  /** The plaintext to seal. */
+  plaintext: Uint8Array;
+  /** Test-vector injection only; omit in production so `enc` is fresh. */
+  ephemeralKey?: HpkeEphemeralKey;
+}
+
+/**
+ * Single-shot Auth-mode seal (`SealAuth`): encrypts `plaintext` so that only
+ * the holder of the recipient private key can open it, and so that opening
+ * also proves the sender held `senderPrivateKey`.
+ *
+ * @returns The encapsulated key (`enc`, 65 bytes) and the AEAD ciphertext.
+ */
+export async function hpkeSealAuth(
+  host: SubtleCrypto,
+  options: HpkeSealOptions,
+): Promise<{ enc: Uint8Array; ciphertext: Uint8Array }> {
+  const { sharedSecret, enc } = await authEncap(
+    host,
+    options.recipientPublicKey,
+    options.senderPrivateKey,
+    options.senderPublicKey,
+    options.ephemeralKey,
+  );
+  const { aeadKey, baseNonce } = await keySchedule(host, sharedSecret, options.info, "encrypt");
+  sharedSecret.fill(0);
+  const ciphertext = new Uint8Array(
+    await host.encrypt(
+      { name: "AES-GCM", iv: bs(baseNonce), additionalData: bs(options.aad) },
+      aeadKey,
+      bs(options.plaintext),
+    ),
+  );
+  return { enc, ciphertext };
+}
+
+/** Inputs for {@link hpkeOpenAuth}. */
+export interface HpkeOpenOptions {
+  /** The encapsulated ephemeral public key (`enc`) from the sealed message. */
+  enc: Uint8Array;
+  /** The recipient's static ECDH private key (`skR`), `deriveBits`-capable. */
+  recipientPrivateKey: CryptoKey;
+  /** The recipient's uncompressed P-256 public point (`pkRm`). */
+  recipientPublicKey: Uint8Array;
+  /** The sender's uncompressed P-256 public point (`pkSm`). */
+  senderPublicKey: Uint8Array;
+  /** The `info` value the sealer used. */
+  info: Uint8Array;
+  /** The additional authenticated data the sealer used. */
+  aad: Uint8Array;
+  /** The AEAD ciphertext to open. */
+  ciphertext: Uint8Array;
+}
+
+/**
+ * Single-shot Auth-mode open (`OpenAuth`): the inverse of
+ * {@link hpkeSealAuth}. Fails (the host AEAD rejects) when the ciphertext was
+ * not sealed to this recipient by the claimed sender, or when any input was
+ * tampered with.
+ *
+ * @returns The recovered plaintext.
+ */
+export async function hpkeOpenAuth(
+  host: SubtleCrypto,
+  options: HpkeOpenOptions,
+): Promise<Uint8Array> {
+  const sharedSecret = await authDecap(
+    host,
+    options.enc,
+    options.recipientPrivateKey,
+    options.recipientPublicKey,
+    options.senderPublicKey,
+  );
+  const { aeadKey, baseNonce } = await keySchedule(host, sharedSecret, options.info, "decrypt");
+  sharedSecret.fill(0);
+  return new Uint8Array(
+    await host.decrypt(
+      { name: "AES-GCM", iv: bs(baseNonce), additionalData: bs(options.aad) },
+      aeadKey,
+      bs(options.ciphertext),
+    ),
+  );
+}

--- a/keystore/core/src/types/backend.ts
+++ b/keystore/core/src/types/backend.ts
@@ -74,6 +74,40 @@ export interface SecretStoreAPI<Ctx = unknown> {
 }
 
 /**
+ * Options for {@link KeyStoreAPI.encryptWithKey}.
+ */
+export interface KeyEncryptionOptions {
+  /**
+   * Optional override for the encryption algorithm. Reserved: the scheme is
+   * currently resolved from the key itself (see
+   * {@link KeyStoreAPI.encryptWithKey}).
+   */
+  algorithm?: string;
+  /**
+   * A third party's public key to encrypt **to**. When present, the ciphertext
+   * is sealed with HPKE (RFC 9180) Auth mode — a key agreement between this
+   * keystore's private key and the recipient's public key — so only the
+   * recipient's private key can open it, and opening proves it came from this
+   * key's holder. Accepts an uncompressed P-256 point (65 bytes) or an SPKI
+   * document (the shape {@link import("./core.ts").Key.publicKey} mirrors for
+   * byte-backed EC keys). When omitted, the data is encrypted for this
+   * keystore alone (self-encryption).
+   */
+  recipientPublicKey?: Uint8Array;
+}
+
+/**
+ * Options for {@link KeyStoreAPI.decryptWithKey}.
+ */
+export interface KeyDecryptionOptions {
+  /**
+   * Optional override for the decryption algorithm. Reserved: the scheme is
+   * resolved from the ciphertext's version byte.
+   */
+  algorithm?: string;
+}
+
+/**
  * Main interface for keystore operations. This defines what a keystore backend must do.
  * Think of it as a "key manager" that can create, store, and use cryptographic keys.
  *
@@ -183,24 +217,69 @@ export interface KeyStoreAPI<Ctx = unknown> {
   verify(id: KeyId, data: Uint8Array, signature: Uint8Array, algorithm?: string): Promise<boolean>;
 
   /**
-   * Encrypts data with a public key (asymmetric encryption).
+   * Encrypts data with the given key, resolving the best scheme from the key
+   * and the options — the private material is always unlocked just-in-time
+   * through the driver, and the ciphertext always stays confidential against
+   * anyone who merely knows a public key.
    *
-   * @param id - The {@link KeyId} to use for encryption.
+   * **Self-encryption** (no `recipientPublicKey`): a symmetric key only this
+   * keystore can reproduce —
+   *
+   * - byte-backed material — AES-GCM key via HKDF-SHA-256 over the sealed
+   *   private bytes (salted with the public key);
+   * - a native `AES-GCM` {@link CryptoKey} — used directly through the host;
+   * - a native `ECDH`/`X25519` {@link CryptoKey} — AES-GCM key derived from a
+   *   self-agreement (the private key against its own public key), a secret
+   *   only the private-key holder can compute.
+   *
+   * **Peer encryption** (`options.recipientPublicKey` set): HPKE (RFC 9180)
+   * **Auth mode** in the `DHKEM(P-256, HKDF-SHA256)` + `HKDF-SHA256` +
+   * `AES-128-GCM` suite — a key agreement between this key's private material
+   * and the recipient's public key, so the recipient (and only the recipient)
+   * can both decrypt the data and verify it came from this key's holder. This
+   * requires an ECDH P-256 key with the `deriveBits` usage; a signing-only or
+   * XHD key throws (run XHD agreements through
+   * {@link deriveSharedSecret} instead, or generate a dedicated ECDH key).
+   *
+   * A signature-only native `CryptoKey` (e.g. a non-extractable Ed25519
+   * signing key) can neither encrypt nor run a key agreement, so it throws in
+   * both modes.
+   *
+   * @param id - The {@link KeyId} whose private material keys the cipher.
    * @param data - The data to encrypt.
-   * @param algorithm - Optional override for the encryption algorithm.
+   * @param options - Optional {@link KeyEncryptionOptions} (recipient, algorithm).
+   * @param ctx - Optional backend-specific context (unlock/authorization).
    * @returns The encrypted data.
    */
-  encryptWithKey?(id: KeyId, data: Uint8Array, algorithm?: string, ctx?: Ctx): Promise<Uint8Array>;
+  encryptWithKey?(
+    id: KeyId,
+    data: Uint8Array,
+    options?: KeyEncryptionOptions,
+    ctx?: Ctx,
+  ): Promise<Uint8Array>;
 
   /**
-   * Decrypts data with a private key.
+   * Decrypts an {@link encryptWithKey} ciphertext, resolving the scheme from
+   * the ciphertext's version byte: a self-encrypted payload re-derives the
+   * symmetric key from this key's **private** material (HKDF over sealed
+   * bytes, the native `AES-GCM` key itself, or an `ECDH`/`X25519`
+   * self-agreement); an HPKE-sealed payload is opened with this key as the
+   * recipient, authenticating the embedded sender public key. Version-1
+   * ciphertexts (the retired public-key-derived scheme, which anyone holding
+   * the public key could decrypt) are rejected.
    *
-   * @param id - The {@link KeyId} to use for decryption.
+   * @param id - The {@link KeyId} whose private material keys the cipher.
    * @param data - The data to decrypt.
-   * @param algorithm - Optional override for the decryption algorithm.
+   * @param options - Optional {@link KeyDecryptionOptions}.
+   * @param ctx - Optional backend-specific context (unlock/authorization).
    * @returns The decrypted data.
    */
-  decryptWithKey?(id: KeyId, data: Uint8Array, algorithm?: string, ctx?: Ctx): Promise<Uint8Array>;
+  decryptWithKey?(
+    id: KeyId,
+    data: Uint8Array,
+    options?: KeyDecryptionOptions,
+    ctx?: Ctx,
+  ): Promise<Uint8Array>;
 
   /**
    * Derives a shared secret for key agreement (e.g., ECDH).

--- a/keystore/node/src/rpc/client.ts
+++ b/keystore/node/src/rpc/client.ts
@@ -22,6 +22,8 @@ import type {
   GenerateOptions,
   Key,
   KeyData,
+  KeyDecryptionOptions,
+  KeyEncryptionOptions,
   KeyFormat,
   KeyId,
   KeyOptions,
@@ -226,10 +228,10 @@ export function createRpcKeyStore(options: RpcKeyStoreOptions): RpcKeyStore {
       call<Uint8Array>("sign", [id, data, algorithm]),
     verify: (id: KeyId, data: Uint8Array, signature: Uint8Array, algorithm?: string) =>
       call<boolean>("verify", [id, data, signature, algorithm]),
-    encryptWithKey: (id: KeyId, data: Uint8Array, algorithm?: string) =>
-      call<Uint8Array>("encryptWithKey", [id, data, algorithm]),
-    decryptWithKey: (id: KeyId, data: Uint8Array, algorithm?: string) =>
-      call<Uint8Array>("decryptWithKey", [id, data, algorithm]),
+    encryptWithKey: (id: KeyId, data: Uint8Array, encryptOptions?: KeyEncryptionOptions) =>
+      call<Uint8Array>("encryptWithKey", [id, data, encryptOptions]),
+    decryptWithKey: (id: KeyId, data: Uint8Array, decryptOptions?: KeyDecryptionOptions) =>
+      call<Uint8Array>("decryptWithKey", [id, data, decryptOptions]),
     deriveSharedSecret: (id: KeyId, publicKey: Uint8Array, meFirst: boolean, algorithm?: string) =>
       call<Uint8Array>("deriveSharedSecret", [id, publicKey, meFirst, algorithm]),
     importSeed: (seed: Uint8Array, seedOptions?: KeyOptions) =>

--- a/keystore/web/src/engine.test.ts
+++ b/keystore/web/src/engine.test.ts
@@ -159,6 +159,125 @@ describe("createWebKeyStore", () => {
     expect(await keystore.verify(id, message, signature)).toBe(true);
   });
 
+  it("encrypts/decrypts natively with a non-extractable AES-GCM CryptoKey", async () => {
+    const id = await keystore.generate({
+      type: "secret-key",
+      algorithm: "AES-GCM",
+      extractable: false,
+      keyUsages: ["encrypt", "decrypt"],
+      params: { length: 256 },
+    });
+    // The key persists as a native CryptoKey — no byte material ever exists.
+    const db = await openDatabase(databaseName, globalThis.indexedDB);
+    const record = await db.get<MaterialRecord>(MATERIAL_STORE, id);
+    expect(record?.kind).toBe("cryptokey");
+    if (record?.kind === "cryptokey") {
+      expect(record.privateKey.extractable).toBe(false);
+    }
+
+    const plaintext = new TextEncoder().encode("host-sealed payload");
+    const ciphertext = await keystore.encryptWithKey!(id, plaintext);
+    expect(ciphertext[0]).toBe(2);
+    const decrypted = await keystore.decryptWithKey!(id, ciphertext);
+    expect(new TextDecoder().decode(decrypted)).toBe("host-sealed payload");
+  });
+
+  it("encrypts/decrypts with a non-extractable ECDH CryptoKey via a self-agreement", async () => {
+    const id = await keystore.generate({
+      type: "ecc",
+      algorithm: "ECDH",
+      extractable: false,
+      keyUsages: ["deriveBits", "deriveKey"],
+      params: { namedCurve: "P-256" },
+    });
+    const db = await openDatabase(databaseName, globalThis.indexedDB);
+    const record = await db.get<MaterialRecord>(MATERIAL_STORE, id);
+    expect(record?.kind).toBe("cryptokey");
+
+    const plaintext = new TextEncoder().encode("agreement-sealed payload");
+    const ciphertext = await keystore.encryptWithKey!(id, plaintext);
+    expect(ciphertext[0]).toBe(2);
+    const decrypted = await keystore.decryptWithKey!(id, ciphertext);
+    expect(new TextDecoder().decode(decrypted)).toBe("agreement-sealed payload");
+  });
+
+  it("encrypts/decrypts with a deriveKey-only ECDH CryptoKey without surfacing bytes", async () => {
+    const id = await keystore.generate({
+      type: "ecc",
+      algorithm: "ECDH",
+      extractable: false,
+      keyUsages: ["deriveKey"],
+      params: { namedCurve: "P-256" },
+    });
+    const plaintext = new TextEncoder().encode("in-host agreement");
+    const ciphertext = await keystore.encryptWithKey!(id, plaintext);
+    const decrypted = await keystore.decryptWithKey!(id, ciphertext);
+    expect(new TextDecoder().decode(decrypted)).toBe("in-host agreement");
+  });
+
+  it("seals to a third-party public key with HPKE using native ECDH CryptoKeys", async () => {
+    const ecdhOptions = {
+      type: "ecc",
+      algorithm: "ECDH",
+      extractable: false,
+      keyUsages: ["deriveBits", "deriveKey"],
+      params: { namedCurve: "P-256" },
+    } as const;
+    const aliceId = await keystore.generate({ ...ecdhOptions, keyUsages: ["deriveBits"] });
+    const bobId = await keystore.generate({ ...ecdhOptions, keyUsages: ["deriveBits"] });
+    // The native branch mirrors the SPKI public bytes into the metadata so a
+    // peer can be handed this key's public key.
+    const bobPublic = store.state.keys.find((k) => k.id === bobId)!.publicKey!;
+    expect(bobPublic).toBeInstanceOf(Uint8Array);
+
+    const plaintext = new TextEncoder().encode("dear bob (native)");
+    const sealed = await keystore.encryptWithKey!(aliceId, plaintext, {
+      recipientPublicKey: bobPublic,
+    });
+    // Peer layout: [version=3 | suite=1 | senderPub(65) | enc(65) | ct].
+    expect(sealed[0]).toBe(3);
+    const opened = await keystore.decryptWithKey!(bobId, sealed);
+    expect(new TextDecoder().decode(opened)).toBe("dear bob (native)");
+    // Only the addressed recipient can open it — not even the sender.
+    await expect(keystore.decryptWithKey!(aliceId, sealed)).rejects.toThrow();
+  });
+
+  it("refuses peer encryption for a deriveKey-only native ECDH CryptoKey", async () => {
+    const senderId = await keystore.generate({
+      type: "ecc",
+      algorithm: "ECDH",
+      extractable: false,
+      keyUsages: ["deriveKey"],
+      params: { namedCurve: "P-256" },
+    });
+    const recipientId = await keystore.generate({
+      type: "ecc",
+      algorithm: "ECDH",
+      extractable: false,
+      keyUsages: ["deriveBits"],
+      params: { namedCurve: "P-256" },
+    });
+    const recipientPublicKey = store.state.keys.find((k) => k.id === recipientId)!.publicKey!;
+    // HPKE concatenates raw DH outputs, which `deriveKey` alone cannot produce.
+    await expect(
+      keystore.encryptWithKey!(senderId, message, { recipientPublicKey }),
+    ).rejects.toThrow(/deriveBits/);
+  });
+
+  it("refuses encryptWithKey for a signature-only native CryptoKey", async () => {
+    const id = await keystore.generate({
+      type: "ed25519",
+      algorithm: "EdDSA",
+      extractable: false,
+      keyUsages: ["sign", "verify"],
+    });
+    // A non-extractable Ed25519 signing key can neither encrypt nor run a key
+    // agreement — there is no secret path to an encryption key for it.
+    await expect(keystore.encryptWithKey!(id, message)).rejects.toThrow(
+      /neither encryption nor key agreement/,
+    );
+  });
+
   it("rehydrates metadata from IndexedDB on reopen and can still sign", async () => {
     const seed = new Uint8Array(32).fill(5);
     const seedId = await keystore.importSeed!(seed);


### PR DESCRIPTION
# Overview

An audit found that `encryptWithKey`/`decryptWithKey` derived their AES-GCM key from the key's **public** bytes, so anyone holding a ciphertext plus the public key could decrypt it. This PR rekeys the API off private material, extends it to keys stored as non-extractable host `CryptoKey`s, and adds third-party encryption via HPKE (RFC 9180) Auth mode.

## What changed

### Self-encryption now requires private material (v2)

- The AES-GCM key is derived with HKDF-SHA-256 over the key's sealed private bytes, unlocked just-in-time through `driver.use` (so interactive backends such as React Native biometrics prompt as expected). The public key is used only as salt.
- The ciphertext version byte is bumped from 1 to 2. Version-1 ciphertexts never had confidentiality and are rejected as unsupported rather than decrypted.

### Native host keys participate

- Keys persisted as non-extractable `CryptoKey`s (e.g. the web/IndexedDB driver) no longer throw. `AES-GCM` keys are used directly through the host Subtle; `ECDH`/`X25519` keys derive the AES key from a self-agreement folded through HKDF.
- Signature-only native keys (e.g. non-extractable Ed25519) still throw `InvalidKeyDataError`, now with a clearer message, since WebCrypto permits neither encryption nor key agreement for them.

### Peer encryption via HPKE (v3)

- The unused positional `algorithm` string parameter is replaced by an options bag: `encryptWithKey(id, data, options?, ctx?)`. `algorithm` lives in the bag as a reserved field, so callers passing two or fewer arguments are unaffected.
- Passing `options.recipientPublicKey` seals the payload with HPKE Auth mode, suite `DHKEM(P-256, HKDF-SHA256) + HKDF-SHA256 + AES-128-GCM`. Only the recipient's private key can open it, and opening authenticates the sender.
- `hpke.ts` (new): a minimal single-shot `SealAuth`/`OpenAuth` built entirely on the injected host `SubtleCrypto`. An off-the-shelf HPKE package was rejected because it discovers `globalThis.crypto` and would bypass the injected-host seam.
- Peer ciphertexts are framed as `[version=3 | suite | senderPub | enc | ct]`, so decrypt is self-contained and dispatches on the version byte. The peer path requires an ECDH P-256 key with `deriveBits` usage; wrong-usage keys throw with guidance to re-import or generate a derivation key.
- `generateHostKey` now mirrors SPKI public bytes into metadata so native keys can be addressed as recipients. The node RPC client forwards the options bag.

## Testing

- `hpke.test.ts` pins conformance to the RFC 9180 Appendix A.3.3 vectors, including an exact ciphertext match.
- New regressions: v1 ciphertexts are refused, a replay of the audited public-key derivation fails to decrypt, sender forgery is rejected, and native AES/ECDH round-trips plus the signature-only refusal are covered in the web engine tests.
- All suites pass: keystore/core (80), web (19), node (22), react-native (91), accounts/keystore-extension (9). `tsc` clean; `pnpm lint` reports 0 errors.

## Compatibility

- Breaking (canary): version-1 ciphertexts can no longer be decrypted, and the third parameter of `encryptWithKey`/`decryptWithKey` is now an options object. Since the old `algorithm` string was ignored, existing callers passing two or fewer arguments keep working.
- Method names and the RPC/engine/prompt surfaces are unchanged.
